### PR TITLE
📝 Add agent rules, PR-based maintenance flow, and commit lint CI.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,6 @@
+<!-- PR title format (CI-enforced): <gitmoji> <Capitalized English one-sentence summary.>
+     e.g. "✨ Add support for custom ports." — see AGENTS.md §2 / CONTRIBUTING.md -->
+
 ## Summary
 <!-- Briefly describe what this PR does -->
 
@@ -9,3 +12,4 @@
 - [ ] Build passes (`just full`)
 - [ ] Smoke test passes on at least one version (`just smoke <version>`)
 - [ ] Manual testing (describe below)
+- [ ] PR title follows `<gitmoji> <Sentence.>` (squash-merged as-is)

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -1,0 +1,55 @@
+name: Commit & PR Lint
+
+# Enforces the commit/PR-title format documented in AGENTS.md §2 and
+# CONTRIBUTING.md ("Commit Conventions"):
+#
+#     <gitmoji> <Capitalized English one-sentence summary ending with a period.>
+#
+# - pull_request: validates the PR title — with squash merge it becomes the
+#   permanent dev commit subject.
+# - push (dev): validates every new non-merge commit, guarding the PR-based
+#   maintenance flow adopted on 2026-09-03 (direct pushes must still be
+#   gitmoji-formatted). Merge commits are allowed on dev (e.g. master→dev
+#   syncs); master pushes are not linted so legacy dev history can still be
+#   merged into master without false failures.
+# `Revert "..."` subjects are exempt; squash suffix ` (#N)` is allowed.
+
+on:
+  pull_request:
+    branches: [master, dev]
+    types: [opened, edited, reopened, synchronize]
+  push:
+    branches: [dev]
+
+concurrency:
+  group: commit-lint-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Lint PR title
+        if: github.event_name == 'pull_request'
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: python scripts/commit_lint.py --subject "$PR_TITLE"
+
+      - name: Lint pushed commits (dev)
+        if: github.event_name == 'push'
+        run: |
+          BEFORE="${{ github.event.before }}"
+          AFTER="${{ github.sha }}"
+          if [ -z "$BEFORE" ] || [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
+            echo "New branch or unknown ancestor — nothing to diff."
+            exit 0
+          fi
+          python scripts/commit_lint.py --range "$BEFORE..$AFTER"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,175 @@
+# AGENTS.md — Rules for AI Agents (minecraft-mod-mcp)
+
+> This file governs every AI agent / subagent / coding tool working in this
+> repository. It was adapted on **2026-09-03** from the Celestia workspace
+> rules (`/mnt/codespace/AGENTS.md` on the yuzu-linux daemon host), keeping
+> only the parts that apply to this repo. Where the Celestia workspace rules
+> conflict with this repo's own conventions ([CONTRIBUTING.md](CONTRIBUTING.md)),
+> **this repo's conventions win**; every deliberate deviation is listed in §9.
+>
+> **Headline change (2026-09-03, maintainer directive): all changes now land
+> through pull requests — including agent-made changes. Do not push directly
+> to `dev` or `master`.**
+
+---
+
+## 1. Branch model
+
+- `dev` — integration branch. **All feature branches and PRs target `dev`.**
+  PRs are **squash-merged** into `dev`, so `dev` stays linear and every commit
+  on it is one reviewed, gitmoji-formatted change.
+- `master` — release line. Receives periodic merges from `dev`; per
+  [CONTRIBUTING](CONTRIBUTING.md#commit-conventions) those merge commits carry
+  the same gitmoji one-sentence subject (never a raw `Merge branch ...` subject).
+- Feature branches: `feat/<name>`, `fix/<name>`, `chore/<name>`,
+  `refactor/<name>`, branched off `origin/dev`.
+- **Difference from Celestia:** the Celestia workspace deprecates `dev`; this
+  repo deliberately keeps it. Do not "fix" this.
+
+## 2. Commit message & PR title format (CI-enforced)
+
+```
+<gitmoji> <Capitalized English one-sentence summary ending with a period.>
+```
+
+- The gitmoji must come from the [gitmoji.dev](https://gitmoji.dev) canonical
+  set, plus the Celestia org additions 🔗 (symlink) 🔄 (sync/refresh)
+  📜 (license) 🛡️ (shield). Commonly used here: ✨ 🐛 🔧 ♻️ 🔥 📝 📦 ⬆️ 👷 ✅ 🚀.
+- The summary is **one plain English sentence**: capitalized first letter,
+  ends with exactly one `.`, printable ASCII only (no CJK).
+- **No colon-prefix shapes** — not `feat:`/`fix(scope):` conventional commits
+  and not `Topic phrase: details` either (e.g. `🔧 Fix compliance: nonce
+  handshake` is forbidden; `🔧 Fix nonce handshake and embed path.` is
+  correct). The gitmoji already conveys the change type. Detailed context
+  belongs in the commit BODY (blank line + bullets), never in the subject.
+- **PR titles follow the exact same rule** — with squash merge, the PR title
+  *becomes* the permanent `dev` commit subject, so it is the single most
+  important line you will write.
+- `Revert "..."` subjects produced by `git revert` are exempt.
+- Squash-merge suffix ` (#123)` is allowed.
+- **Exception (repo convention):** development commits on feature branches may
+  use conventional-commit prefixes for internal clarity — they are squashed
+  away at merge time anyway. Gitmoji format is still preferred everywhere.
+- Local check before pushing: `just lint-commits` (validates
+  `origin/dev..HEAD`). CI runs the same linter (`scripts/commit_lint.py`) on
+  every PR title and on every new commit pushed to `dev`.
+
+## 3. PR workflow (per task)
+
+1. **Create a feature branch** off `origin/dev`. If multiple agents share one
+   checkout, work in an isolated `git worktree` (never edit the main checkout
+   concurrently with another agent); remove the worktree after merge.
+2. **3-round verify cycle** for each change: analyze → improve → verify, three
+   rounds over; if any round fails, restart the count from zero. Use subagents
+   for verification to keep the main context clean.
+3. **Non-trivial tasks must go through subagents** (or equivalent isolation):
+   give them exact file paths, the conventions above, and verification
+   criteria; launch independent sub-tasks in parallel.
+4. **Verify locally before pushing**: `just full` for build changes (or at
+   minimum the touched package: `just mcp-build`, `just mcp-lint`, relevant
+   `just build-mod`), `just lint-commits` always. Run `just smoke <version>`
+   when behavior can only be proven in-game.
+5. **Push** the branch, **open a PR** against `dev` (via `gh pr create`) with
+   a compliant title and a filled-in PR template.
+6. **Merge** once required checks are green: **squash merge**, subject = PR
+   title, then **delete the branch**.
+7. **PR economy**: bundle one coherent feature/fix wave per PR; do not open a
+   separate PR per trivial tweak. Small PRs are fine for urgent hotfixes or
+   when nothing else is pending.
+8. **Version bumps belong in the main PR**: bump
+   `packages/minecraft-mod-mcp/package.json` inside the feature/fix PR that
+   warrants a release; never open standalone version-bump PRs. Releases are
+   then tag-driven (`git tag vX.Y.Z && git push --tags`).
+9. Merging may be done autonomously by an agent once required checks pass and
+   the title/body comply. Never merge over a genuine code-level failure;
+   infra/environmental check failures may be waived only when documented in
+   the PR and local verification passed.
+
+## 4. Git push discipline
+
+- **NEVER use bare `git push --force`** — no exceptions for "convenience".
+- Prefer `git push --force-with-lease` for rebase/amend recovery on your own
+  feature branch.
+- If `--force-with-lease` is rejected (stale remote-tracking ref), **STOP**.
+  Never fall back to `--force`: fetch, inspect with
+  `git log origin/<branch>..HEAD` and `git log HEAD..origin/<branch>`, and ask
+  the maintainer if anything is unaccounted for.
+- Force-pushes of any kind to `dev`/`master` are forbidden; both branches only
+  advance forward.
+- This applies to all agents, subagents, and interactive sessions.
+
+## 5. Sensitive information red line (hard rule)
+
+> Learned from a real incident in the Celestia family: a live SSH password
+> committed to a repo required history rewriting. Treat a violation here as an
+> incident of the same severity.
+
+1. **Never put real passwords / keys / tokens / internal IPs into the git
+   tree** — any file, branch, comment, example, test fixture, or doc. This
+   includes the Celestia workspace files (`/mnt/codespace/AGENTS.md`,
+   `PLAN.md`), which contain real credentials: read them for context if you
+   must, but **never copy their values into any file of this repo** (including
+   this AGENTS.md).
+2. Need a secret in code? Use environment variables / untracked config files,
+   or obvious placeholders (`<your-token>`, `CHANGE_ME`, `sk-xxx`). Example
+   addresses use RFC 5737 documentation ranges (192.0.2.x / 198.51.100.x /
+   203.0.113.x) and example values (`test-password`).
+3. If a real credential is genuinely required, **ask the maintainer first**;
+   never write it on your own authority.
+4. **Before committing** anything touching config/deploy/scripts/fixtures:
+   grep your diff for `password|secret|token|api_key` and for `192.168.` /
+   `10.` internal addresses; replace hits per the rules above.
+5. If a leak happens anyway: remove it from the branch/PR, assess the blast
+   radius (tags/branches/forks), report to the maintainer, and treat the
+   credential as public — rotate it regardless of any history rewrite.
+
+## 6. Verification & CI usage
+
+- CI runs on GitHub-hosted runners (public repo → free; unlike the Celestia
+  self-hosted fleet, there is no shared-runner quota to protect, but the
+  Windows mod matrix is slow — see below).
+- Every workflow already sets `concurrency` + `cancel-in-progress`, so stale
+  runs are cancelled automatically; do not add workflows without a
+  `concurrency` group.
+- **What runs where**: on PRs — the build matrix (`ci.yml`) plus the fast
+  commit/PR-title lint (`commit-lint.yml`). On `push` to `dev`/`master` — the
+  full pipeline including smoke/screenshot/E2E tests, plus the dev push-format
+  guard.
+- **CI is a gate for code failures, not a tea ceremony**: for docs/config-only
+  changes you may merge once the lint check is green and the relevant code
+  checks pass, without waiting out the full Windows build matrix — record the
+  waiver in the PR. Never merge over a real compile/test failure; if checks
+  are merely queued, wait or re-run instead of force-merging.
+- Do not sit and watch CI. If a run is stuck queued for an unusually long
+  time, investigate (`gh run list`, `gh run cancel <id>`) instead of stacking
+  more pushes on top.
+
+## 7. CHANGELOG policy
+
+- **Never create a CHANGELOG / revision-history file in this repo.** The
+  merged PRs are the changelog: the squash subject + PR description form the
+  complete history, and `git log` serves any granularity.
+- Release notes live on the git tag / GitHub Releases page (written per
+  release, never per commit) — the `release.yml` workflow already does this.
+
+## 8. Local lint recipe
+
+```bash
+just lint-commits                    # validate origin/dev..HEAD
+just lint-commits origin/master..dev # validate any range
+python scripts/commit_lint.py --subject "✨ Add a new tool."   # one subject
+```
+
+## 9. Deliberately NOT adopted from the Celestia workspace rules
+
+| Celestia rule | Why not here |
+|---|---|
+| §0.6 large-download / sing-box proxy discipline | Specific to the yuzu-linux NAT/proxy network and its airport-quota incidents; this repo builds on GitHub-hosted runners and the maintainer's Windows machine. |
+| §1 node table, passwords, NFS layout | Workspace infrastructure — and per §5 above, its credentials must never be copied into this repo. |
+| §2 Celestia-island repo layout | Different family of repositories. |
+| §5 "`dev` is DEPRECATED" | This repo keeps `dev` as its integration branch (§1). |
+| §5 merge-commit subjects rejected | Reversed here: `master` receives `dev` via merge commits whose subjects follow §2 (CONTRIBUTING rule, kept). |
+| §7 Rust/pnpm/CARGO_HOME & self-hosted runner ops | This is a Gradle/npm/Python repo on hosted runners. |
+| §7 "CI 是参考不是门禁" waiver culture | Softened: hosted CI is the real gate here; only documented waivers for docs-only changes (§6). |
+| §8 node-2/3 deployment & malkuth supervision | No deployment fleet; releases are tag-driven GitHub Releases. |
+| §9 pnpm registry / sibling links / worktree symlink discipline | NFS multi-agent infra that does not exist here. |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,28 +78,34 @@ cd packages/minecraft-mod-mcp && npm test
 
 ## Commit Conventions
 
-### Merge into `master`
-
-All merges into `master` (PR merge, dev → master) must use a merge commit message following this format:
+All commit subjects and PR titles follow one format:
 
 ```
-{emoji} {English summary}
+<gitmoji> <Capitalized English one-sentence summary ending with a period.>
 ```
 
-- **Emoji** — must be one from [gitmoji.dev](https://gitmoji.dev) that matches the change (e.g. `🚀` for first release, `✨` for new feature, `🐛` for bugfix, `📝` for docs)
-- **Summary** — concise one-line English, **no conventional-commit prefix** (no `feat:`, `fix:`, `chore:`, etc.), **no version number**, **no filler**
+- **Gitmoji** — from the [gitmoji.dev](https://gitmoji.dev) canonical set (e.g. `✨` new feature, `🐛` bugfix, `📝` docs, `🔧` config, `👷` CI), followed by exactly one space
+- **Summary** — one plain English sentence: capitalized, ends with exactly one `.`, no CJK, **no conventional-commit prefix** (`feat:`, `fix:`, …), **no `Topic phrase:` colon-prefix shape**, **no version number**, **no filler**; detailed context belongs in the commit body
+- **PR titles follow the same rule** — PRs are squash-merged into `dev`, so the PR title becomes the permanent commit subject
+- `Revert "..."` subjects (from `git revert`) and squash suffixes ` (#123)` are exempt
 
 Examples:
 
 ```
-✨ AI-generated mod code can now control the game via MCP tools
-🐛 Fix crash when switching dimensions on Forge 1.21.7
-📝 Restructure documentation for modder-first experience
+✨ AI-generated mod code can now control the game via MCP tools.
+🐛 Fix crash when switching dimensions on Forge 1.21.7.
+📝 Restructure documentation for modder-first experience.
 ```
 
-### Development commits (non-master)
+Development commits on feature branches may still use a conventional-commit prefix for internal clarity (`feat:`, `fix:`, `docs:`, etc.) — they are squashed away at merge time anyway; the gitmoji format is preferred everywhere.
 
-Development commits on feature branches or `dev` may use a conventional-commit prefix for internal clarity (`feat:`, `fix:`, `docs:`, etc.) — the strict rules above apply only to `master` merges.
+Check before pushing:
+
+```bash
+just lint-commits   # validates origin/dev..HEAD
+```
+
+CI enforces the same rules on every PR title and on every new commit pushed to `dev` (see `scripts/commit_lint.py`). AI coding agents must additionally follow [AGENTS.md](AGENTS.md).
 
 ---
 
@@ -120,13 +126,16 @@ Use the [Feature Request](https://github.com/langyo/minecraft-mod-mcp/issues/new
 
 ### Pull Requests
 
-1. Create a feature branch from `dev`
+1. Create a feature branch from `dev` (`feat/<name>` / `fix/<name>` / `chore/<name>`)
 2. Make your changes, following existing code style
 3. Ensure `just full` builds successfully
 4. Run `just smoke <version>` on at least one Minecraft version
-5. Open a PR against `dev` using the [PR template](https://github.com/langyo/minecraft-mod-mcp/blob/dev/.github/PULL_REQUEST_TEMPLATE.md)
+5. Open a PR against `dev` using the [PR template](https://github.com/langyo/minecraft-mod-mcp/blob/dev/.github/PULL_REQUEST_TEMPLATE.md), with the title in the commit format above
+6. Once checks pass, the PR is **squash-merged** into `dev` and the branch deleted
 
-PRs should target `dev`. The `master` branch receives periodic merges from `dev` (see [Commit Conventions](#commit-conventions)).
+PRs target `dev` and are squash-merged, keeping `dev` history linear — one reviewed, gitmoji-formatted commit per change. The `master` branch receives periodic merges from `dev` (see [Commit Conventions](#commit-conventions)).
+
+> **Since 2026-09-03** all changes land through PRs, including maintainer and agent changes; direct pushes to `dev`/`master` are no longer part of the workflow, and CI flags non-compliant direct pushes to `dev`.
 
 ### Code Style
 

--- a/justfile
+++ b/justfile
@@ -170,6 +170,12 @@ dry-run version loader="forge":
 # Utilities
 # ============================================================
 
+# Lint commit messages against the AGENTS.md gitmoji format
+# Usage: just lint-commits                        (origin/dev..HEAD)
+#        just lint-commits origin/master..dev
+lint-commits range="origin/dev..HEAD":
+    python scripts/commit_lint.py --range {{ range }}
+
 # ============================================================
 # Release
 # ============================================================

--- a/scripts/commit_lint.py
+++ b/scripts/commit_lint.py
@@ -1,0 +1,166 @@
+"""Commit message / PR title linter for minecraft-mod-mcp.
+
+Enforces the format documented in AGENTS.md section 2 and CONTRIBUTING.md:
+
+    <gitmoji> <Capitalized English one-sentence summary ending with a period.>
+
+Rules:
+  1. Subject starts with a whitelisted gitmoji, then exactly one space.
+  2. Summary is printable ASCII (no CJK), first character capitalized.
+  3. Summary ends with exactly one '.'.
+  4. No conventional-commit prefixes (``feat:``, ``fix(scope):``, ...) and no
+     ``Topic phrase:`` colon-prefix shape -- write one plain sentence instead.
+  5. ``Revert "..."`` subjects produced by ``git revert`` are exempt.
+  6. Squash-merge suffix `` (#123)`` is allowed.
+
+Usage:
+  python scripts/commit_lint.py --subject "✨ Add a new tool."
+  python scripts/commit_lint.py --range origin/dev..HEAD
+  python scripts/commit_lint.py --range A..B --check-merges
+"""
+
+import argparse
+import re
+import subprocess
+import sys
+
+# gitmoji.dev canonical set (variation selectors stripped) plus the Celestia
+# org additions: 🔗 symlink, 🔄 sync/refresh, 📜 license, 🛡 shield.
+GITMOJIS = frozenset(
+    """
+    🎨 ⚡ 🔥 🐛 🚑 ✨ 📝 🚀 💄 🎉 ✅ 🔒 👮 🔖 🚨 💚 📱 ⬇ ⬆ 🩹 👷 📈 ♻ ➕ ➖
+    🔧 🔨 🌐 ✏ 💩 ⏪ 🔀 📦 👽 🚚 📄 💥 🍱 ♿ 💡 🍸 💬 🗃 🔊 🔇 👥 🚸 🏗 🧐
+    🧪 👔 🩺 🧱 🧑‍💻 💸 🧵 🦺 🥅 💫 ⚰ 🔍 🏷 🌱
+    🔗 🔄 📜 🛡
+    """.split()
+)
+
+SQUASH_SUFFIX = re.compile(r" \(\#\d+\)$")
+CONVENTIONAL_PREFIX = re.compile(
+    r"^(feat|fix|chore|docs|style|refactor|perf|test|build|ci|revert|hack|wip|hotfix)"
+    r"(\([^)]*\))?!?:\s"
+)
+COLON_PREFIX = re.compile(r"^[A-Za-z][\w'\-]*(\s+[\w'\-]+){0,4}:(?!//)")
+
+MAX_SUBJECT_LEN = 100
+
+
+def normalize(text):
+    return text.replace("\ufe0f", "").strip()
+
+
+def check_subject(raw):
+    """Return None if the subject complies, otherwise a human-readable reason."""
+    subject = normalize(raw)
+
+    if subject.startswith('Revert "'):
+        return None
+
+    matched = None
+    for emoji in sorted(GITMOJIS, key=len, reverse=True):
+        if subject.startswith(emoji):
+            matched = emoji
+            break
+    if matched is None:
+        return "must start with a whitelisted gitmoji (gitmoji.dev set, see AGENTS.md \u00a72)"
+
+    summary = subject[len(matched):]
+    if not summary.startswith(" ") or summary.startswith("  "):
+        return "exactly one space required between gitmoji and summary"
+
+    summary = summary.strip()
+    summary = SQUASH_SUFFIX.sub("", summary)
+    if not summary:
+        return "empty summary"
+
+    if len(subject) > MAX_SUBJECT_LEN:
+        return "subject longer than %d characters, keep it to one concise sentence" % MAX_SUBJECT_LEN
+
+    if not summary.isascii():
+        return "summary must be English (printable ASCII, no CJK)"
+
+    if not (summary[0].isupper() or summary[0].isdigit()):
+        return "summary must start with a capital letter"
+
+    if not summary.endswith(".") or summary.endswith(".."):
+        return "summary must end with exactly one '.'"
+
+    if CONVENTIONAL_PREFIX.match(summary):
+        return "conventional-commit prefix is forbidden; write one plain sentence"
+
+    if COLON_PREFIX.match(summary):
+        return "colon-prefix shape ('Topic phrase: details') is forbidden; write the whole change as one sentence"
+
+    return None
+
+
+def collect_range(commit_range, check_merges):
+    """Yield (sha, subject) pairs for commits in a git range."""
+    out = git("log", "--no-merges", "--pretty=%H%x1f%s", commit_range)
+    for line in out.splitlines():
+        if line.strip():
+            sha, subject = line.split("\x1f", 1)
+            yield sha, subject
+    if check_merges:
+        out = git("log", "--merges", "--pretty=%H%x1f%s", commit_range)
+        for line in out.splitlines():
+            if line.strip():
+                sha, subject = line.split("\x1f", 1)
+                yield sha, subject
+
+
+def git(*args):
+    result = subprocess.run(
+        ["git", *args],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=True,
+    )
+    return result.stdout
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--subject", help="validate a single subject line")
+    group.add_argument("--range", dest="commit_range", help="validate commits in a git range")
+    parser.add_argument(
+        "--check-merges",
+        action="store_true",
+        help="with --range: also lint merge-commit subjects",
+    )
+    args = parser.parse_args()
+
+    failures = []
+    if args.subject is not None:
+        reason = check_subject(args.subject)
+        if reason:
+            failures.append(("(subject)", args.subject, reason))
+    else:
+        for sha, subject in collect_range(args.commit_range, args.check_merges):
+            reason = check_subject(subject)
+            if reason:
+                failures.append((sha[:9], subject, reason))
+
+    if failures:
+        for sha, subject, reason in failures:
+            print("FAIL %s %s" % (sha, subject))
+            print("     -> %s" % reason)
+        print(
+            "\n%d violation(s). Format: <gitmoji> <Capitalized English one-sentence "
+            "summary ending with a period.>  See AGENTS.md \u00a72." % len(failures)
+        )
+        return 1
+
+    print("OK" if args.subject is not None else "OK, all commits comply.")
+    return 0
+
+
+if __name__ == "__main__":
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding="utf-8", errors="replace")
+        except AttributeError:
+            pass
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adopts the repo-applicable parts of the Celestia workspace rules (`/mnt/codespace/AGENTS.md` on the yuzu-linux daemon host) and switches this repo to PR-based maintenance, per the 2026-09-03 maintainer directive. This PR itself follows the new flow.

## Changes

- **AGENTS.md** (new) — agent rules adapted from the Celestia workspace file: PR-first workflow, gitmoji commit/PR-title format, squash merge into `dev`, force-push discipline, sensitive-info red line, CHANGELOG ban, CI usage policy. Sections that conflict with this repo's conventions (dev-branch model, hosted CI, no deploy fleet…) are deliberately not adopted and listed in §9.
- **scripts/commit_lint.py** (new) — standalone linter for the commit format (gitmoji whitelist, capitalized English one-sentence summary with trailing period, no conventional/colon prefixes, CJK ban; `Revert "…"` and squash ` (#N)` exempt).
- **.github/workflows/commit-lint.yml** (new) — lints PR titles on PRs to `dev`/`master` and every new commit pushed to `dev` (merge commits allowed; master not linted so legacy dev history can still sync over).
- **CONTRIBUTING.md / PR template / justfile** — synced with the unified format; added `just lint-commits` for pre-push checks.

## Tested

- [x] `scripts/commit_lint.py` unit-checked against compliant and violating subjects (suffix ` (#N)`, `Revert`, colon-prefix, CJK, lowercase, merge subjects)
- [x] Self-lint: `just lint-commits` passes for this branch's commit
- [ ] Full build not re-run — docs/tooling-only change (no Java/TS/Python runtime code paths touched)