### PR TITLE
📝 Note the dev branch protection in agent rules and contributing guide.

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,10 @@
 
 - `dev` — integration branch. **All feature branches and PRs target `dev`.**
   PRs are **squash-merged** into `dev`, so `dev` stays linear and every commit
-  on it is one reviewed, gitmoji-formatted change.
+  on it is one reviewed, gitmoji-formatted change. Since 2026-09-03 `dev` is
+  **branch-protected**: PRs are required (0 approvals — self-merge is fine),
+  the `lint` check is required, and force-pushes/deletions are blocked for
+  everyone including the maintainer.
 - `master` — release line. Receives periodic merges from `dev`; per
   [CONTRIBUTING](CONTRIBUTING.md#commit-conventions) those merge commits carry
   the same gitmoji one-sentence subject (never a raw `Merge branch ...` subject).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,7 +135,7 @@ Use the [Feature Request](https://github.com/langyo/minecraft-mod-mcp/issues/new
 
 PRs target `dev` and are squash-merged, keeping `dev` history linear — one reviewed, gitmoji-formatted commit per change. The `master` branch receives periodic merges from `dev` (see [Commit Conventions](#commit-conventions)).
 
-> **Since 2026-09-03** all changes land through PRs, including maintainer and agent changes; direct pushes to `dev`/`master` are no longer part of the workflow, and CI flags non-compliant direct pushes to `dev`.
+> **Since 2026-09-03** all changes land through PRs, including maintainer and agent changes: `dev` is branch-protected (PR required, `lint` check required, no force-pushes), and CI additionally flags non-compliant direct pushes.
 
 ### Code Style
 


### PR DESCRIPTION
## Summary

Follow-up to #3: `dev` is now branch-protected (PR required with 0 approvals, required `lint` check, no force-pushes/deletions, enforced for admins too). Documents the actual enforcement in AGENTS.md §1 and CONTRIBUTING.md.

## Changes

- AGENTS.md §1: mention the protection rules alongside the squash-merge policy.
- CONTRIBUTING.md: reword the 2026-09-03 note to point at the protection instead of only the CI flag.

## Tested

- [x] Docs-only change (waiver per AGENTS.md §6); this PR itself exercises the protected flow end to end.