### PR TITLE
📝 Retire the dev branch and target master for all pull requests.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [master, main, dev]
+    branches: [master, main]
   pull_request:
-    branches: [master, main, dev]
+    branches: [master, main]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -6,20 +6,18 @@ name: Commit & PR Lint
 #     <gitmoji> <Capitalized English one-sentence summary ending with a period.>
 #
 # - pull_request: validates the PR title — with squash merge it becomes the
-#   permanent dev commit subject.
-# - push (dev): validates every new non-merge commit, guarding the PR-based
-#   maintenance flow adopted on 2026-09-03 (direct pushes must still be
-#   gitmoji-formatted). Merge commits are allowed on dev (e.g. master→dev
-#   syncs); master pushes are not linted so legacy dev history can still be
-#   merged into master without false failures.
+#   permanent master commit subject.
+# - push (master): validates every new commit, merge-commit subjects included.
+#   master is squash-merge only, so a merge commit landing here means someone
+#   bypassed the PR flow — the linter rejects `Merge branch ...` subjects.
 # `Revert "..."` subjects are exempt; squash suffix ` (#N)` is allowed.
 
 on:
   pull_request:
-    branches: [master, dev]
+    branches: [master]
     types: [opened, edited, reopened, synchronize]
   push:
-    branches: [dev]
+    branches: [master]
 
 concurrency:
   group: commit-lint-${{ github.event_name }}-${{ github.ref }}
@@ -43,7 +41,7 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: python scripts/commit_lint.py --subject "$PR_TITLE"
 
-      - name: Lint pushed commits (dev)
+      - name: Lint pushed commits (master)
         if: github.event_name == 'push'
         run: |
           BEFORE="${{ github.event.before }}"
@@ -52,4 +50,4 @@ jobs:
             echo "New branch or unknown ancestor — nothing to diff."
             exit 0
           fi
-          python scripts/commit_lint.py --range "$BEFORE..$AFTER"
+          python scripts/commit_lint.py --range "$BEFORE..$AFTER" --check-merges

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -14,7 +14,7 @@ name: Website
 
 on:
   push:
-    branches: [master, dev]
+    branches: [master]
     paths:
       - 'docs/website/**'
       - '.github/workflows/website.yml'

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -77,10 +77,10 @@ jobs:
           fi
 
       - name: Type check
-        run: npx vue-tsc -b --noEmit
+        run: pnpm exec vue-tsc -b --noEmit
 
       - name: Build (Vite)
-        run: npx vite build --base "${{ steps.base.outputs.base }}"
+        run: pnpm exec vite build --base "${{ steps.base.outputs.base }}"
 
       - name: Generate favicons & copy assets
         run: python3 scripts/build.py --skip-deps --skip-typecheck --skip-vite

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,26 +8,25 @@
 > **this repo's conventions win**; every deliberate deviation is listed in §9.
 >
 > **Headline change (2026-09-03, maintainer directive): all changes now land
-> through pull requests — including agent-made changes. Do not push directly
-> to `dev` or `master`.**
+> through pull requests into `master` — including agent-made changes. The old
+> `dev` integration branch is retired; do not push directly to `master`.**
 
 ---
 
 ## 1. Branch model
 
-- `dev` — integration branch. **All feature branches and PRs target `dev`.**
-  PRs are **squash-merged** into `dev`, so `dev` stays linear and every commit
-  on it is one reviewed, gitmoji-formatted change. Since 2026-09-03 `dev` is
-  **branch-protected**: PRs are required (0 approvals — self-merge is fine),
-  the `lint` check is required, and force-pushes/deletions are blocked for
-  everyone including the maintainer.
-- `master` — release line. Receives periodic merges from `dev`; per
-  [CONTRIBUTING](CONTRIBUTING.md#commit-conventions) those merge commits carry
-  the same gitmoji one-sentence subject (never a raw `Merge branch ...` subject).
+- `master` — the only long-lived branch. **Protected since 2026-09-03**: PRs
+  are required (0 approvals — self-merge is fine), the `lint` check is
+  required, force-pushes/deletions are blocked for everyone including the
+  maintainer, and the repo only offers squash merge. Every `master` commit is
+  therefore one reviewed, gitmoji-formatted change — same model as the
+  Celestia workspace (their §5).
+- `dev` — **retired on 2026-09-03** (branch deleted). Before deletion,
+  `master` was fast-forwarded to the final `dev` tip, so no history was lost.
+  Do not recreate `dev`; old `dev`-based local branches should be rebased onto
+  `master`.
 - Feature branches: `feat/<name>`, `fix/<name>`, `chore/<name>`,
-  `refactor/<name>`, branched off `origin/dev`.
-- **Difference from Celestia:** the Celestia workspace deprecates `dev`; this
-  repo deliberately keeps it. Do not "fix" this.
+  `refactor/<name>`, branched off `origin/master`.
 
 ## 2. Commit message & PR title format (CI-enforced)
 
@@ -46,7 +45,7 @@
   correct). The gitmoji already conveys the change type. Detailed context
   belongs in the commit BODY (blank line + bullets), never in the subject.
 - **PR titles follow the exact same rule** — with squash merge, the PR title
-  *becomes* the permanent `dev` commit subject, so it is the single most
+  *becomes* the permanent `master` commit subject, so it is the single most
   important line you will write.
 - `Revert "..."` subjects produced by `git revert` are exempt.
 - Squash-merge suffix ` (#123)` is allowed.
@@ -54,14 +53,15 @@
   use conventional-commit prefixes for internal clarity — they are squashed
   away at merge time anyway. Gitmoji format is still preferred everywhere.
 - Local check before pushing: `just lint-commits` (validates
-  `origin/dev..HEAD`). CI runs the same linter (`scripts/commit_lint.py`) on
-  every PR title and on every new commit pushed to `dev`.
+  `origin/master..HEAD`). CI runs the same linter (`scripts/commit_lint.py`)
+  on every PR title and on every new commit pushed to `master` — including
+  merge-commit subjects, which are rejected: master is squash-merge only.
 
 ## 3. PR workflow (per task)
 
-1. **Create a feature branch** off `origin/dev`. If multiple agents share one
-   checkout, work in an isolated `git worktree` (never edit the main checkout
-   concurrently with another agent); remove the worktree after merge.
+1. **Create a feature branch** off `origin/master`. If multiple agents share
+   one checkout, work in an isolated `git worktree` (never edit the main
+   checkout concurrently with another agent); remove the worktree after merge.
 2. **3-round verify cycle** for each change: analyze → improve → verify, three
    rounds over; if any round fails, restart the count from zero. Use subagents
    for verification to keep the main context clean.
@@ -72,8 +72,8 @@
    minimum the touched package: `just mcp-build`, `just mcp-lint`, relevant
    `just build-mod`), `just lint-commits` always. Run `just smoke <version>`
    when behavior can only be proven in-game.
-5. **Push** the branch, **open a PR** against `dev` (via `gh pr create`) with
-   a compliant title and a filled-in PR template.
+5. **Push** the branch, **open a PR against `master`** (via `gh pr create`)
+   with a compliant title and a filled-in PR template.
 6. **Merge** once required checks are green: **squash merge**, subject = PR
    title, then **delete the branch**.
 7. **PR economy**: bundle one coherent feature/fix wave per PR; do not open a
@@ -97,8 +97,8 @@
   Never fall back to `--force`: fetch, inspect with
   `git log origin/<branch>..HEAD` and `git log HEAD..origin/<branch>`, and ask
   the maintainer if anything is unaccounted for.
-- Force-pushes of any kind to `dev`/`master` are forbidden; both branches only
-  advance forward.
+- Force-pushes of any kind to `master` are forbidden; it only advances
+  forward via squash merge.
 - This applies to all agents, subagents, and interactive sessions.
 
 ## 5. Sensitive information red line (hard rule)
@@ -134,10 +134,10 @@
 - Every workflow already sets `concurrency` + `cancel-in-progress`, so stale
   runs are cancelled automatically; do not add workflows without a
   `concurrency` group.
-- **What runs where**: on PRs — the build matrix (`ci.yml`) plus the fast
-  commit/PR-title lint (`commit-lint.yml`). On `push` to `dev`/`master` — the
-  full pipeline including smoke/screenshot/E2E tests, plus the dev push-format
-  guard.
+- **What runs where**: on PRs to `master` — the build matrix (`ci.yml`) plus
+  the fast commit/PR-title lint (`commit-lint.yml`). On `push` to `master` —
+  the full pipeline including smoke/screenshot/E2E tests, plus the
+  push-format guard.
 - **CI is a gate for code failures, not a tea ceremony**: for docs/config-only
   changes you may merge once the lint check is green and the relevant code
   checks pass, without waiting out the full Windows build matrix — record the
@@ -158,8 +158,8 @@
 ## 8. Local lint recipe
 
 ```bash
-just lint-commits                    # validate origin/dev..HEAD
-just lint-commits origin/master..dev # validate any range
+just lint-commits                     # validate origin/master..HEAD
+just lint-commits v0.2.0..master      # validate any range
 python scripts/commit_lint.py --subject "✨ Add a new tool."   # one subject
 ```
 
@@ -170,9 +170,10 @@ python scripts/commit_lint.py --subject "✨ Add a new tool."   # one subject
 | §0.6 large-download / sing-box proxy discipline | Specific to the yuzu-linux NAT/proxy network and its airport-quota incidents; this repo builds on GitHub-hosted runners and the maintainer's Windows machine. |
 | §1 node table, passwords, NFS layout | Workspace infrastructure — and per §5 above, its credentials must never be copied into this repo. |
 | §2 Celestia-island repo layout | Different family of repositories. |
-| §5 "`dev` is DEPRECATED" | This repo keeps `dev` as its integration branch (§1). |
-| §5 merge-commit subjects rejected | Reversed here: `master` receives `dev` via merge commits whose subjects follow §2 (CONTRIBUTING rule, kept). |
 | §7 Rust/pnpm/CARGO_HOME & self-hosted runner ops | This is a Gradle/npm/Python repo on hosted runners. |
 | §7 "CI 是参考不是门禁" waiver culture | Softened: hosted CI is the real gate here; only documented waivers for docs-only changes (§6). |
 | §8 node-2/3 deployment & malkuth supervision | No deployment fleet; releases are tag-driven GitHub Releases. |
 | §9 pnpm registry / sibling links / worktree symlink discipline | NFS multi-agent infra that does not exist here. |
+
+> The Celestia §5 model (master-only, squash-merge only, `dev` deprecated) is
+> **adopted** here as of 2026-09-03 — see §1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,7 +86,7 @@ All commit subjects and PR titles follow one format:
 
 - **Gitmoji** — from the [gitmoji.dev](https://gitmoji.dev) canonical set (e.g. `✨` new feature, `🐛` bugfix, `📝` docs, `🔧` config, `👷` CI), followed by exactly one space
 - **Summary** — one plain English sentence: capitalized, ends with exactly one `.`, no CJK, **no conventional-commit prefix** (`feat:`, `fix:`, …), **no `Topic phrase:` colon-prefix shape**, **no version number**, **no filler**; detailed context belongs in the commit body
-- **PR titles follow the same rule** — PRs are squash-merged into `dev`, so the PR title becomes the permanent commit subject
+- **PR titles follow the same rule** — PRs are squash-merged into `master`, so the PR title becomes the permanent commit subject
 - `Revert "..."` subjects (from `git revert`) and squash suffixes ` (#123)` are exempt
 
 Examples:
@@ -102,10 +102,10 @@ Development commits on feature branches may still use a conventional-commit pref
 Check before pushing:
 
 ```bash
-just lint-commits   # validates origin/dev..HEAD
+just lint-commits   # validates origin/master..HEAD
 ```
 
-CI enforces the same rules on every PR title and on every new commit pushed to `dev` (see `scripts/commit_lint.py`). AI coding agents must additionally follow [AGENTS.md](AGENTS.md).
+CI enforces the same rules on every PR title and on every new commit pushed to `master`, merge-commit subjects included — master is squash-merge only (see `scripts/commit_lint.py`). AI coding agents must additionally follow [AGENTS.md](AGENTS.md).
 
 ---
 
@@ -126,16 +126,16 @@ Use the [Feature Request](https://github.com/langyo/minecraft-mod-mcp/issues/new
 
 ### Pull Requests
 
-1. Create a feature branch from `dev` (`feat/<name>` / `fix/<name>` / `chore/<name>`)
+1. Create a feature branch from `master` (`feat/<name>` / `fix/<name>` / `chore/<name>`)
 2. Make your changes, following existing code style
 3. Ensure `just full` builds successfully
 4. Run `just smoke <version>` on at least one Minecraft version
-5. Open a PR against `dev` using the [PR template](https://github.com/langyo/minecraft-mod-mcp/blob/dev/.github/PULL_REQUEST_TEMPLATE.md), with the title in the commit format above
-6. Once checks pass, the PR is **squash-merged** into `dev` and the branch deleted
+5. Open a PR against `master` using the [PR template](https://github.com/langyo/minecraft-mod-mcp/blob/master/.github/PULL_REQUEST_TEMPLATE.md), with the title in the commit format above
+6. Once checks pass, the PR is **squash-merged** into `master` and the branch deleted
 
-PRs target `dev` and are squash-merged, keeping `dev` history linear — one reviewed, gitmoji-formatted commit per change. The `master` branch receives periodic merges from `dev` (see [Commit Conventions](#commit-conventions)).
+PRs target `master` and are squash-merged, keeping its history linear — one reviewed, gitmoji-formatted commit per change. The `master` branch is protected: PRs are required (0 approvals — self-merge is fine), the `lint` check must pass, and force-pushes/deletions are blocked for everyone.
 
-> **Since 2026-09-03** all changes land through PRs, including maintainer and agent changes: `dev` is branch-protected (PR required, `lint` check required, no force-pushes), and CI additionally flags non-compliant direct pushes.
+> **Since 2026-09-03** all changes land through squash-merged PRs into `master`, including maintainer and agent changes. The former `dev` integration branch is retired (its history lives on in `master`, which was fast-forwarded to the final `dev` tip before deletion).
 
 ### Code Style
 

--- a/justfile
+++ b/justfile
@@ -171,9 +171,9 @@ dry-run version loader="forge":
 # ============================================================
 
 # Lint commit messages against the AGENTS.md gitmoji format
-# Usage: just lint-commits                        (origin/dev..HEAD)
-#        just lint-commits origin/master..dev
-lint-commits range="origin/dev..HEAD":
+# Usage: just lint-commits                          (origin/master..HEAD)
+#        just lint-commits v0.2.0..master
+lint-commits range="origin/master..HEAD":
     python scripts/commit_lint.py --range {{ range }}
 
 # ============================================================

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,1 +1,0 @@
-packages: []

--- a/scripts/commit_lint.py
+++ b/scripts/commit_lint.py
@@ -15,7 +15,7 @@ Rules:
 
 Usage:
   python scripts/commit_lint.py --subject "✨ Add a new tool."
-  python scripts/commit_lint.py --range origin/dev..HEAD
+  python scripts/commit_lint.py --range origin/master..HEAD
   python scripts/commit_lint.py --range A..B --check-merges
 """
 


### PR DESCRIPTION
## Summary

Switches the repo to the Celestia §5 model: **master is the only branch** — all PRs target it and are squash-merged; the `dev` integration branch is retired (maintainer directive, 2026-09-03). Before this PR, `master` was fast-forwarded to the final `dev` tip (092c850) via a non-force ref update, so all dev history and work is preserved — this PR contains only the follow-up convention changes.

## Changes

- **AGENTS.md §1**: rewritten for the master-only model (protected, squash-merge only, PR required with 0 approvals); §2/§3/§4/§6/§8 dev references updated; §9 notes the now-adopted Celestia rows.
- **CONTRIBUTING.md**: PR flow now targets `master`; branch protection documented; dev retirement noted.
- **commit-lint.yml**: triggers on `master` only; the push guard now lints merge-commit subjects too (`--check-merges`) — master must never see `Merge branch ...` subjects.
- **ci.yml / website.yml**: `dev` dropped from branch triggers.
- **justfile / scripts/commit_lint.py**: default lint range is `origin/master..HEAD`.

## Tested

- [x] `scripts/commit_lint.py --range origin/master..HEAD` passes for this branch's commit
- [x] All workflow YAML files parse cleanly
- [ ] Build matrix waived: docs/tooling-only change (recorded per AGENTS.md §6)