### PR TITLE
🐛 Build the MCP CLI and grant dev-release permissions in CI helper jobs.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,6 +292,8 @@ jobs:
     runs-on: windows-latest
     needs: build-mods
     if: github.event_name == 'push'
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
 
@@ -425,6 +427,12 @@ jobs:
           echo "DISPLAY=:99" >> $GITHUB_ENV
           echo "LIBGL_ALWAYS_SOFTWARE=true" >> $GITHUB_ENV
           echo "GALLIUM_DRIVER=llvmpipe" >> $GITHUB_ENV
+      - name: Build MCP CLI
+        run: |
+          cd packages/minecraft-mod-mcp
+          npm ci --no-audit --no-fund
+          npm run build
+
       - name: Run smoke test
         id: smoke
         run: |
@@ -504,6 +512,12 @@ jobs:
           echo "DISPLAY=:99" >> $GITHUB_ENV
           echo "LIBGL_ALWAYS_SOFTWARE=true" >> $GITHUB_ENV
           echo "GALLIUM_DRIVER=llvmpipe" >> $GITHUB_ENV
+      - name: Build MCP CLI
+        run: |
+          cd packages/minecraft-mod-mcp
+          npm ci --no-audit --no-fund
+          npm run build
+
       - name: Run screenshot test
         run: |
           python scripts/ci_helper.py screenshot-test \
@@ -576,6 +590,12 @@ jobs:
           echo "DISPLAY=:99" >> $GITHUB_ENV
           echo "LIBGL_ALWAYS_SOFTWARE=true" >> $GITHUB_ENV
           echo "GALLIUM_DRIVER=llvmpipe" >> $GITHUB_ENV
+      - name: Build MCP CLI
+        run: |
+          cd packages/minecraft-mod-mcp
+          npm ci --no-audit --no-fund
+          npm run build
+
       - name: Run E2E test
         id: e2e
         run: |


### PR DESCRIPTION
## Summary

Follow-up to #7: now that the build lanes are green again, the previously always-skipped lanes ran for the first time and exposed two latent workflow bugs.

## Changes

- **Headless smoke / screenshot / E2E jobs**: they invoke `packages/minecraft-mod-mcp/dist/cli.js` via `ci_helper.py`, but nothing ever built the npm package (`dist/` is gitignored) — every job died with `MODULE_NOT_FOUND`. Added a `Build MCP CLI` step (`npm ci` + `npm run build`) to each job before the helper runs.
- **Dev Release job**: creating the dev prerelease failed with `403 Resource not accessible by integration`; granted the job `permissions: contents: write`.

## Tested

- [x] Failure signatures verified from the master pipeline logs (all 19 smoke jobs + E2E show `MODULE_NOT_FOUND` from `dist/cli.js`; Dev Release shows the 403).
- [x] `npm ci && npm run build` is the same sequence used locally (`just mcp-build`).
- [ ] CI on this PR (smoke lanes run on push to master).