### PR TITLE
🐛 Use npm install instead of npm ci to build the MCP CLI in CI.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -430,7 +430,7 @@ jobs:
       - name: Build MCP CLI
         run: |
           cd packages/minecraft-mod-mcp
-          npm ci --no-audit --no-fund
+          npm install --no-audit --no-fund
           npm run build
 
       - name: Run smoke test
@@ -515,7 +515,7 @@ jobs:
       - name: Build MCP CLI
         run: |
           cd packages/minecraft-mod-mcp
-          npm ci --no-audit --no-fund
+          npm install --no-audit --no-fund
           npm run build
 
       - name: Run screenshot test
@@ -593,7 +593,7 @@ jobs:
       - name: Build MCP CLI
         run: |
           cd packages/minecraft-mod-mcp
-          npm ci --no-audit --no-fund
+          npm install --no-audit --no-fund
           npm run build
 
       - name: Run E2E test


### PR DESCRIPTION
## Summary

Follow-up to #8: the `Build MCP CLI` step used `npm ci`, but `packages/minecraft-mod-mcp` ships no `package-lock.json`, so `npm ci` exits with EUSAGE — which took down the entire smoke/screenshot/E2E batch on master (all 40+ jobs).

## Changes

- `npm ci --no-audit --no-fund` → `npm install --no-audit --no-fund` in the three helper jobs' Build MCP CLI steps.

## Tested

- [x] Failure signature verified from the master pipeline log (`npm error code EUSAGE ... can only install with an existing package-lock.json`).
- [x] YAML validated; only the three step bodies changed.
- [ ] Master pipeline after merge (helper lanes only run on push).