### PR TITLE
🐛 Pass the mod JAR to the CLI launcher in CI helper paths.

### DIFF
--- a/scripts/ci_helper.py
+++ b/scripts/ci_helper.py
@@ -640,7 +640,7 @@ def run_smoke_test(mc_ver, loader, jdk_ver, mod_jar, headless=True, world_name=N
             ["node", launcher, "launch", version_name, "--headless",
              "--memory", "512",
              "--extra-jvm", extra_jvm,
-             "--no-mod-sync"],
+             "--mod-jar", str(mod_jar)],
             env=env, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
             text=True, bufsize=1,
         )
@@ -764,7 +764,7 @@ def run_e2e_test(mc_ver, loader, jdk_ver, mod_jar, world_name, timeout=600):
 
     mc_proc = subprocess.Popen(
         ["node", launcher, "launch", version_name,
-         "--memory", "512"],
+         "--memory", "512", "--mod-jar", str(mod_jar)],
         env=env, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
         text=True, bufsize=1,
     )
@@ -909,7 +909,7 @@ def main():
         launcher = str(Path(__file__).resolve().parent.parent / "packages" / "minecraft-mod-mcp" / "dist" / "cli.js")
         mc_proc = subprocess.Popen(
             ["node", launcher, "launch", version_name,
-             "--memory", "512"],
+             "--memory", "512", "--mod-jar", str(args.mod_jar)],
             env=os.environ.copy(),
             stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
             text=True, bufsize=1,


### PR DESCRIPTION
## Summary

Follow-up to #10: the smoke jobs now install and launch the game correctly, but every one times out "Waiting for mod..." because the mod never loads.

## Root cause

The helper launches through `cli.js launch`, which runs the game in an isolated game dir (`~/.minecraft/mcp_launcher/game`). The CLI only copies the mod into that instance's `mods/` when `--mod-jar` is passed (`deployModToModsDir` in launch.ts). The helper never passed it — and passed `--no-mod-sync`, which is not a CLI option at all. So Forge had no mod to load and the in-game HTTP server never started.

## Changes

- Wire `--mod-jar` into all three helper launch sites (smoke, screenshot test, E2E) and drop the bogus `--no-mod-sync`.

## Tested

- [x] Root cause traced from the CI log (`Game Dir: /home/runner/.minecraft/mcp_launcher/game` + "Waiting for mod..." timeout) to the launch.ts deploy guard.
- [x] `py_compile` clean.
- [ ] Master pipeline after merge.