### PR TITLE
🐛 Declare headless and extra-jvm flags in the launch argument parser.

### DIFF
--- a/packages/minecraft-mod-mcp/src/cli.ts
+++ b/packages/minecraft-mod-mcp/src/cli.ts
@@ -183,9 +183,20 @@ Options:
       "server-port": { type: "string", default: String(GAME.defaultServerPort) },
       "dry-run": { type: "boolean", default: false },
       "mod-jar": { type: "string" },
+      headless: { type: "boolean", default: false },
+      // multiple: "--extra-jvm -Da=x -Db=y" would otherwise be shredded by
+      // parseArgs when the value starts with "-" (strict:false treats the
+      // flag as boolean and explodes the value into one-char tokens).
+      "extra-jvm": { type: "string", multiple: true },
     },
     strict: false,
   });
+
+  // --extra-jvm may be passed multiple times (or hold several properties);
+  // normalize to one space-joined string.
+  const extraJvmFlags = Array.isArray(values["extra-jvm"])
+    ? (values["extra-jvm"] as string[]).join(" ")
+    : (values["extra-jvm"] as string | undefined);
 
   const versionArg = positionals[0];
   const loader = (values.loader ?? GAME.defaultLoader) as Loader;
@@ -203,6 +214,7 @@ Options:
   const extraJvmParts: string[] = [];
   if (config.java_args) extraJvmParts.push(config.java_args);
   if (typeof values["jvm-args"] === "string") extraJvmParts.push(values["jvm-args"]);
+  if (typeof extraJvmFlags === "string") extraJvmParts.push(extraJvmFlags);
 
   const launchConfig: LaunchConfig = {
     versionId,


### PR DESCRIPTION
## Summary

Root cause of the smoke batch failing with "Waiting for mod..." timeouts: the `launch` subcommand's `parseArgs` (strict:false) never declared `--headless` or `--extra-jvm`, so passing `--extra-jvm "-Djava.awt.headless=true -Dmcp.test.world=X"` turned the flag boolean and exploded the value into junk one-char tokens that dragged `--mod-jar` (and `--memory`) into positionals. The helper's `--mod-jar` was therefore silently dropped, the CLI never deployed the mod into the isolated game dir, FML loaded nothing, and the in-game HTTP bridge never started.

## Changes

- Declare `headless` (boolean) and `extra-jvm` (string, multiple) in runLaunch's parseArgs; join repeated `--extra-jvm` values back into one flag string wired into `extraJvmArgs`.

## Tested

- [x] Parsed-args repro before/after (values vs positionals) — confirmed the flag-shredding and the fix.
- [x] Full local end-to-end on 1.12.2/forge via `ci_helper.run_smoke_test`: mod deployed → FML loads `mcpmod` → HTTP bridge answers `ping`, `get_player_info`, `get_world_info`, `execute_command` (screenshot needs a GL context, which CI's Xvfb+llvmpipe provides).
- [x] tsc clean; mcp-build OK.
- [ ] Master pipeline after merge.