### PR TITLE
🐛 Persist the game's stdout and stderr under the instance logs dir.

### DIFF
--- a/packages/minecraft-mod-mcp/src/cli.ts
+++ b/packages/minecraft-mod-mcp/src/cli.ts
@@ -13,7 +13,7 @@ import { fetchVersionManifest, fetchVersionJson, downloadVersion, listInstalledV
 import { versionsDir, classpathSeparator, ensureModJar } from "./mc/platform.js";
 import { findFreePort } from "./discovery/scanner.js";
 import { spawn } from "node:child_process";
-import { existsSync, mkdirSync, readdirSync, statSync, copyFileSync } from "node:fs";
+import { existsSync, mkdirSync, readdirSync, statSync, copyFileSync, openSync, closeSync } from "node:fs";
 import { gradleProxyEnv, setupGlobalProxy } from "./mc/proxy.js";
 import { join, resolve } from "node:path";
 import { GAME, MCP, PLAYER, SERVER, SERVER_TYPES, type ServerType } from "./mc/defaults.js";
@@ -273,12 +273,21 @@ Options:
   if (launchConfig.fullscreen) console.error(`  Fullscreen: true`);
   else console.error(`  Resolution: ${launchConfig.width}x${launchConfig.height}`);
 
+  // Keep the game's stderr on disk: a JVM that dies before logging
+  // (bad classpath, missing natives) otherwise vanishes without a trace,
+  // which made CI smoke failures undiagnosable.
+  const logsDir = join(mcDir_, "logs");
+  if (!existsSync(logsDir)) mkdirSync(logsDir, { recursive: true });
+  const stderrFd = openSync(join(logsDir, "mc-stderr.log"), "a");
+  const stdoutFd = openSync(join(logsDir, "mc-stdout.log"), "a");
   const child = spawn(cmd.java, cmd.args, {
     cwd: mcDir_,
-    stdio: "ignore",
+    stdio: ["ignore", stdoutFd, stderrFd],
     detached: true,
   });
   child.unref();
+  // Close the parent's copies; the detached child keeps its own.
+  try { closeSync(stderrFd); closeSync(stdoutFd); } catch {}
 
   child.on("error", (err) => {
     console.error(`Launch failed: ${err.message}`);

--- a/scripts/ci_helper.py
+++ b/scripts/ci_helper.py
@@ -423,6 +423,17 @@ def _dump_launch_diagnostics():
         _log(f"[diag] game mods: {sorted(p.name for p in mods.glob('*.jar'))}")
     else:
         _log(f"[diag] game mods dir missing: {mods}")
+    for stderr_name in ("mc-stderr.log", "mc-stdout.log"):
+        stderr_log = game_dir / "logs" / stderr_name
+        if stderr_log.is_file() and stderr_log.stat().st_size > 0:
+            try:
+                lines = stderr_log.read_text(encoding="utf-8", errors="replace").splitlines()
+                if lines:
+                    _log(f"[diag] {stderr_name} (last 15 lines):")
+                    for l in lines[-15:]:
+                        _log(f"  [MC] {l[:200]}")
+            except Exception as e:
+                _log(f"[diag] failed reading {stderr_name}: {e}")
     log = game_dir / "logs" / "latest.log"
     if log.is_file():
         try:


### PR DESCRIPTION
Follow-up to #13: the smoke diagnostics showed the game dying before writing any log (empty latest.log, dead java), but the launcher's stdio:"ignore" swallowed the JVM's own error output. Redirect both streams to <gameDir>/logs/mc-stdout.log and mc-stderr.log from the detached spawn (file descriptors survive the parent exiting), and have the timeout diagnostics dump them. Diagnostic plumbing for the in-progress smoke-lane stabilization; tsc + build clean, verified the descriptors build locally.