### PR TITLE
🐛 Only pass curl its resume flag when a partial file exists.

### DIFF
--- a/packages/minecraft-mod-mcp/src/mc/proxy.ts
+++ b/packages/minecraft-mod-mcp/src/mc/proxy.ts
@@ -72,15 +72,20 @@ async function nativeDownload(url: string, destPath: string): Promise<void> {
     });
   }
   return new Promise<void>((resolve, reject) => {
-    // -C - resumes from a partial file; --retry/-all-errors/-delay survive the
-    // socket resets / throttling that hit large downloads (JDK tarballs, mod JARs)
-    // from international CDNs. curl skips cleanly when the file is already complete.
-    execFile("curl", [
-      "-fSL", "-C -",
+    // --retry/-all-errors/-delay survive the socket resets / throttling that
+    // hit large downloads (JDK tarballs, mod JARs) from international CDNs.
+    // Resume (-C -) only when a partial file exists: curl >= 8 aborts with
+    // "option -C -: expected a proper numerical parameter" when the output
+    // file is missing, which killed every cold JDK download on CI runners.
+    const { existsSync } = require("node:fs") as typeof import("node:fs");
+    const curlArgs = ["-fSL"];
+    if (existsSync(destPath)) curlArgs.push("-C", "-");
+    curlArgs.push(
       "--retry", "5", "--retry-all-errors", "--retry-delay", "3",
       "--connect-timeout", "60",
       "-o", destPath, url,
-    ], { timeout: 600_000 }, (err) => {
+    );
+    execFile("curl", curlArgs, { timeout: 600_000 }, (err) => {
       if (err) reject(err);
       else resolve();
     });


### PR DESCRIPTION
## Summary

Root cause of the CI smoke lanes dying with zero output: the launcher's native download fallback always passed `curl -fSL -C -`, but curl ≥ 8 aborts with `option -C -: expected a proper numerical parameter` when the output file doesn't exist yet. Every cold JDK download on the Linux runners (needed when the required JDK isn't already installed) therefore failed before writing a byte, the game never spawned, and the timeout diagnostics showed empty logs plus a dead java process.

## Changes

- Enable `-C -` only when the destination file already exists (i.e. resuming a partial download).

## Tested

- [x] Reproduced in WSL (Ubuntu 24.04, curl 8): pre-fix launch died at the curl error; post-fix the JDK 8 tarball downloads to 100%, extracts, and the game launches with it (it then reaches OpenGL init, which only fails locally for lack of Xvfb — CI provides Xvfb+llvmpipe).
- [x] tsc + build clean.
- [ ] Master smoke lanes after merge.