### PR TITLE
🐛 Resolve the mod JAR to an absolute path before launching.

### DIFF
--- a/packages/minecraft-mod-mcp/src/cli.ts
+++ b/packages/minecraft-mod-mcp/src/cli.ts
@@ -220,7 +220,12 @@ Options:
     versionId,
     mcDir: typeof values["mc-dir"] === "string" ? values["mc-dir"] : gameDirPath(config),
     loader,
-    modJar: typeof values["mod-jar"] === "string" ? values["mod-jar"] : (await ensureModJar(versionArg, loader)) ?? undefined,
+    // The jar enters the classpath and is deployed into the isolated game
+    // dir; a relative path would resolve against the game dir at runtime
+    // and kill the JVM with "could not find main class".
+    modJar: typeof values["mod-jar"] === "string"
+      ? resolve(values["mod-jar"])
+      : (await ensureModJar(versionArg, loader)) ?? undefined,
     mcpPort: typeof values.port === "string" ? parseInt(values.port, 10) : config.mcp_port ?? await findFreePort(),
     dryRun: values["dry-run"] === true,
     maxMemoryMb: parseInt(typeof values.memory === "string" ? values.memory : String(config.max_memory_mb), 10),


### PR DESCRIPTION
## Summary

The dry-run plan printed by the smoke diagnostics (#16) exposed the final launch blocker: the classpath carried the `--mod-jar` value verbatim. The CI helper passes a path relative to the repo root, the game resolves it against its own game dir, the JVM cannot find the main class, and it dies with zero output — matching every remaining smoke failure signature exactly.

## Changes

- `resolve()` the `--mod-jar` value before it enters the launch config (classpath + mods-dir deploy).

## Tested

- [x] WSL end-to-end: with the fix the dry-run classpath shows the absolute path, and the real launch reaches FML mod loading (18 log lines) instead of dying instantly; the eventual crash there is WSL's missing Xvfb, which CI provides.
- [x] tsc + build clean.
- [ ] Master smoke lanes after merge.