### PR TITLE
🐛 Disable the Forge early display window in CI smoke launches.

### DIFF
--- a/scripts/ci_helper.py
+++ b/scripts/ci_helper.py
@@ -678,6 +678,11 @@ def run_smoke_test(mc_ver, loader, jdk_ver, mod_jar, headless=True, world_name=N
                                                        os.environ.get("JAVA_HOME", "")))
 
     extra_jvm = "-Djava.awt.headless=true"
+    # Forge >= 1.20.5 opens an early GL window that times out under
+    # Xvfb/llvmpipe ("Timed out trying to setup the Game Window");
+    # older loaders ignore the property.
+    if loader == "forge":
+        extra_jvm += " -Dforge.disableEarlyDisplay=true"
     if world_name:
         extra_jvm += f" -Dmcp.test.world={world_name}"
 


### PR DESCRIPTION
The 26.2-forge smoke (and any forge >= 1.20.5) dies in EarlyDisplay: llvmpipe fails the GL 4.0/3.3 probes and the game window setup times out before the mod loads. Pass the official -Dforge.disableEarlyDisplay=true on forge launches; older loaders ignore the property. Exercised by push-event lanes; py-compile clean.