### PR TITLE
🐛 Fix the four remaining smoke-lane failure classes.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -361,7 +361,8 @@ jobs:
           - { mc_ver: "1.19.4",  loader: "forge",    jdk: "17" }
           - { mc_ver: "1.19.4",  loader: "fabric",   jdk: "17" }
           - { mc_ver: "1.20.4",  loader: "forge",    jdk: "17" }
-          - { mc_ver: "1.20.4",  loader: "neoforge", jdk: "17" }
+          # 1.20.4-neoforge omitted: NeoForge 49.x never shipped an installer
+          # (HTTP 404 upstream), so there is no runtime to smoke-test.
           - { mc_ver: "1.20.6",  loader: "forge",    jdk: "21" }
           - { mc_ver: "1.20.6",  loader: "fabric",   jdk: "21" }
           - { mc_ver: "1.20.6",  loader: "neoforge", jdk: "21" }

--- a/packages/minecraft-mod-mcp/src/mc/download.ts
+++ b/packages/minecraft-mod-mcp/src/mc/download.ts
@@ -451,14 +451,15 @@ export async function downloadFabricLoader(
   if (!existsSync(vDir)) mkdirSync(vDir, { recursive: true });
 
   const jsonPath = join(vDir, `${versionId}.json`);
-  if (existsSync(jsonPath)) {
-    onProgress?.(`Fabric loader ${versionId} already installed.`);
-    return;
+  if (!existsSync(jsonPath)) {
+    writeFileSync(jsonPath, JSON.stringify(profileJson, null, 2), "utf-8");
+    onProgress?.(`Saved version JSON for ${versionId}`);
   }
 
-  writeFileSync(jsonPath, JSON.stringify(profileJson, null, 2), "utf-8");
-  onProgress?.(`Saved version JSON for ${versionId}`);
-
+  // Always ensure the profile libraries exist: the loader jar (KnotClient)
+  // and friends may be missing when the version json was written by an
+  // older install path — without them the JVM dies with
+  // ClassNotFoundException at launch.
   await downloadLibraries(profileJson.libraries, onProgress);
 
   onProgress?.(`Fabric ${versionId} install complete`);

--- a/packages/minecraft-mod-mcp/src/mc/launch.ts
+++ b/packages/minecraft-mod-mcp/src/mc/launch.ts
@@ -230,9 +230,9 @@ export function buildLaunchCommand(config: LaunchConfig, vj: VersionJson, data?:
   ensureOptionsTxt(mcDir);
 
   // Deploy the mod JAR into the instance's mods/ directory for every loader.
-  // Fabric loads from mods/ (deploy) AND we add it to the classpath below; Forge
-  // and NeoForge discover mods almost exclusively from mods/, so without this
-  // copy the in-game MCP HTTP server never starts on those loaders.
+  // All three loaders discover mods from mods/ — the jar must NOT also enter
+  // the classpath: on module-aware Forge (1.17+) the duplicate Automatic-Module
+  // triggers "ResolutionException: module mcpmod contains package ..." at boot.
   if (config.modJar && existsSync(config.modJar)) {
     deployModToModsDir(mcDir, config.modJar);
   }
@@ -253,10 +253,6 @@ export function buildLaunchCommand(config: LaunchConfig, vj: VersionJson, data?:
 
   const versionJar = join(versionsDir(), config.versionId, `${config.versionId}.jar`);
   if (existsSync(versionJar) && versionJar !== baseJar) classpathPaths.push(versionJar);
-
-  if (config.modJar && existsSync(config.modJar)) {
-    classpathPaths.unshift(config.modJar);
-  }
 
   const needsSortFix = needsLegacySortFix(config.versionId, targetJavaVersion);
   let sortFixApplied = false;

--- a/packages/minecraft-mod-mcp/src/mc/proxy.ts
+++ b/packages/minecraft-mod-mcp/src/mc/proxy.ts
@@ -59,18 +59,42 @@ const sleep = (ms: number) => new Promise<void>(r => setTimeout(r, ms));
 
 async function nativeDownload(url: string, destPath: string): Promise<void> {
   const { execFile } = await import("node:child_process");
+  const { existsSync: fsExists } = await import("node:fs");
   if (process.platform === "win32") {
-    const ps = ["Invoke-WebRequest", "-Uri", url, "-OutFile", destPath, "-TimeoutSec", "60"];
-    return new Promise<void>((resolve, reject) => {
-      execFile("powershell", ["-NoProfile", "-Command", ...ps], {
-        timeout: 120_000,
-        windowsHide: true,
-      }, (err) => {
-        if (err) reject(err);
-        else resolve();
+    // Prefer the curl.exe shipped with Windows 10+ (resolved from PATH):
+    // it retries and keeps going through the connection resets that kill
+    // Invoke-WebRequest mid-download (large installer jars from CDNs).
+    // If curl is not on PATH this rejects with ENOENT and we fall back.
+    const curlArgs = [
+      "-fSL",
+      "--retry", "5", "--retry-all-errors", "--retry-delay", "3",
+      "--connect-timeout", "60",
+      "-o", destPath, url,
+    ];
+    try {
+      const { execFile: ef } = await import("node:child_process");
+      await new Promise<void>((resolve, reject) => {
+        ef("curl", curlArgs, { timeout: 900_000, windowsHide: true }, (err: unknown) => {
+          if (err) reject(err);
+          else resolve();
+        });
       });
-    });
+      return;
+    } catch (curlErr: any) {
+      if (curlErr?.code !== "ENOENT") throw curlErr;
+      const ps = ["Invoke-WebRequest", "-Uri", url, "-OutFile", destPath, "-TimeoutSec", "300"];
+      return new Promise<void>((resolve, reject) => {
+        execFile("powershell", ["-NoProfile", "-Command", ...ps], {
+          timeout: 360_000,
+          windowsHide: true,
+        }, (err) => {
+          if (err) reject(err);
+          else resolve();
+        });
+      });
+    }
   }
+
   return new Promise<void>((resolve, reject) => {
     // --retry/-all-errors/-delay survive the socket resets / throttling that
     // hit large downloads (JDK tarballs, mod JARs) from international CDNs.

--- a/packages/minecraft-mod-mcp/src/mc/versions-embedded.json
+++ b/packages/minecraft-mod-mcp/src/mc/versions-embedded.json
@@ -381,7 +381,7 @@
       "version_id": "1.20.6-forge-50.2.8",
       "mappings": "official_1.20.6",
       "fabric_yarn": "1.20.6+build.1",
-      "neoforge": "20.6.139",
+      "neoforge": "20.6.134",
       "mdg": "2.0.141"
     },
     "1_21": {

--- a/packages/mods/1.20.6/neoforge/build.gradle
+++ b/packages/mods/1.20.6/neoforge/build.gradle
@@ -25,7 +25,7 @@ dependencies {
 }
 
 neoForge {
-    version = "20.6.139"
+    version = "20.6.134"
     runs {
         configureEach {
             gameDirectory = project.file('run')

--- a/scripts/ci_helper.py
+++ b/scripts/ci_helper.py
@@ -76,7 +76,27 @@ def setup_mc_version(mc_ver, loader, mc_dir=None):
         return None
 
     elif loader == "fabric":
-        return _install_fabric_json(mc_ver, mc)
+        # Install through the CLI like forge/neoforge: it fetches the profile
+        # AND downloads the loader libraries (KnotClient et al.). Writing the
+        # profile json here directly used to skip the library downloads and
+        # the JVM then died with ClassNotFoundException.
+        mcp_cli = str(Path(__file__).resolve().parent.parent / "packages" / "minecraft-mod-mcp" / "dist" / "cli.js")
+        _log(f"Running MCP CLI install for {mc_ver} (fabric)...")
+        env_clean = {k: v for k, v in os.environ.items()
+                     if not k.lower().endswith("proxy") and k.lower() != "all_proxy"}
+        env_clean["HOME"] = str(Path(mc).parent)
+        env_clean["JAVA_HOME"] = os.environ.get("JAVA_HOME", "")
+        result = subprocess.run(
+            ["node", mcp_cli, "install", mc_ver, "--loader", "fabric"],
+            env=env_clean, capture_output=True, text=True, timeout=600)
+        if result.returncode != 0:
+            _log(f"MCP install stderr: {result.stderr[-500:]}")
+        installed = _find_installed(mc_ver, loader, mc)
+        if installed:
+            _log(f"Installed: {installed}")
+            return installed
+        _log(f"Install failed for {mc_ver}/fabric")
+        return None
 
     return None
 
@@ -136,6 +156,18 @@ _LEGACY_FABRIC_LOADERS = {
     "1.20.4": "0.16.14", "1.20.6": "0.16.14",
     "1.21.11": "0.16.14",
 }
+
+
+def _fabric_loader_pin(mc_ver: str) -> str | None:
+    """Loader version for a MC version: version_config pin, else the legacy table."""
+    try:
+        from version_config import ALL_VERSIONS
+        info = ALL_VERSIONS.get(mc_ver, {})
+        if info.get("fabric_loader"):
+            return info["fabric_loader"]
+    except Exception:
+        pass
+    return _LEGACY_FABRIC_LOADERS.get(mc_ver, "0.16.14")
 
 
 def _find_installed(mc_ver: str, loader: str, mc_dir: str | None = None) -> str | None:
@@ -677,12 +709,15 @@ def run_smoke_test(mc_ver, loader, jdk_ver, mod_jar, headless=True, world_name=N
                                        os.environ.get(f"JAVA_HOME_{jdk_ver}",
                                                        os.environ.get("JAVA_HOME", "")))
 
-    extra_jvm = "-Djava.awt.headless=true"
+    # No -Djava.awt.headless=true: with Xvfb there IS a display, and the
+    # property breaks LWJGL2's X connection on pre-1.13 Minecraft
+    # ("LWJGLException: Could not open X display connection").
+    extra_jvm = ""
     # Forge >= 1.20.5 opens an early GL window that times out under
     # Xvfb/llvmpipe ("Timed out trying to setup the Game Window");
     # older loaders ignore the property.
     if loader == "forge":
-        extra_jvm += " -Dforge.disableEarlyDisplay=true"
+        extra_jvm += "-Dforge.disableEarlyDisplay=true"
     if world_name:
         extra_jvm += f" -Dmcp.test.world={world_name}"
 

--- a/scripts/version_config.py
+++ b/scripts/version_config.py
@@ -216,7 +216,7 @@ ALL_VERSIONS = {
                "neoforge": "49.0.51"},
     "1.20.6": {"forge": "1.20.6-50.2.8",                   "fg_era": "fg6",  "java": 21, "mappings": "official_1.20.6",
                "version_id": "1.20.6-forge-50.2.8",
-               "neoforge": "20.6.139", "mdg": "2.0.141",
+               "neoforge": "20.6.134", "mdg": "2.0.141",
                "fabric_yarn": "1.20.6+build.1"},
     "1.21":   {"forge": "1.21-51.0.33",                    "fg_era": "fg6",  "java": 21, "mappings": "official_1.21",
                "version_id": "1.21-Forge51.0.33", "fabric_yarn": "1.21+build.1"},


### PR DESCRIPTION
## Summary

Clears every remaining smoke-lane failure class from the last master pipeline (26 failures → all four root causes fixed or removed).

## Root causes & fixes

1. **All fabric versions — `ClassNotFoundException: KnotClient`**: the smoke helper wrote the loader profile json itself, short-circuiting the CLI install and its library downloads (fabric-loader jar never landed on disk). The helper now installs through the CLI, and `downloadFabricLoader` re-ensures profile libraries even when the version json already exists.
2. **1.17/1.19 forge — `ResolutionException`**: the launcher injected the mod jar into the classpath *in addition to* deploying it into `mods/`; module-aware Forge aborted over the duplicated package. The jar now only deploys into `mods/` (verified in WSL: `DuplicateModsFoundException` gone).
3. **1.7–1.16 forge — `LWJGLException: Could not open X display connection`**: `-Djava.awt.headless=true` breaks LWJGL2's X connection under Xvfb. Xvfb *is* the display, so the flag is removed (verified in WSL: 1.12.2 reaches the in-game HTTP bridge and answers `get_player_info`).
4. **NeoForge installs**: Windows native downloads prefer retry-hardened `curl.exe` over one-shot `Invoke-WebRequest`; 1.20.6 moves from `20.6.139` (no installer upstream — HTTP 404) to `20.6.134` (installer verified, mod rebuilt locally, CLI install succeeds); 1.20.4-neoforge leaves the smoke matrix because the 49.x line never shipped installers at all (build lane unchanged — the jar itself builds fine).

## Tested

- [x] WSL (Xvfb + llvmpipe): 1.12.2-forge launches, mod loads, HTTP bridge answers commands.
- [x] Local: 1.20.6/neoforge rebuilt (195s) and CLI install succeeds with 20.6.134.
- [x] Probed upstream maven: 49.x installers 404 everywhere (incl. forge mirror), 20.6.134 installer+userdev 200.
- [x] tsc + mcp-build clean; embedded versions regenerated; py-compile clean.
- [ ] Master pipeline after merge.