### PR TITLE
🐛 Scope the headless JVM flag to LWJGL3 versions and align the Xvfb mode.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -506,10 +506,10 @@ jobs:
           sudo apt-get install -y -qq xvfb libgl1-mesa-glx libgl1-mesa-dri x11-xserver-utils 2>/dev/null || true
       - name: Start Xvfb
         run: |
-          Xvfb :99 -screen 0 1280x720x24 -ac +extension RANDR +extension GLX -nolisten tcp &
+          Xvfb :99 -screen 0 1024x768x24 -ac +extension RANDR +extension GLX -nolisten tcp &
           sleep 2
-          xrandr --newmode "1280x720_60" 74.50 1280 1344 1472 1664 720 723 728 748 -hsync +vsync 2>/dev/null || true
-          xrandr --addmode default 1280x720_60 2>/dev/null || true
+          xrandr --newmode "1024x768_60" 63.50 1024 1072 1176 1328 768 771 775 798 -hsync +vsync 2>/dev/null || true
+          xrandr --addmode default 1024x768_60 2>/dev/null || true
           echo "DISPLAY=:99" >> $GITHUB_ENV
           echo "LIBGL_ALWAYS_SOFTWARE=true" >> $GITHUB_ENV
           echo "GALLIUM_DRIVER=llvmpipe" >> $GITHUB_ENV
@@ -584,10 +584,10 @@ jobs:
           sudo apt-get install -y -qq xvfb libgl1-mesa-glx libgl1-mesa-dri x11-xserver-utils 2>/dev/null || true
       - name: Start Xvfb
         run: |
-          Xvfb :99 -screen 0 1280x720x24 -ac +extension RANDR +extension GLX -nolisten tcp &
+          Xvfb :99 -screen 0 1024x768x24 -ac +extension RANDR +extension GLX -nolisten tcp &
           sleep 2
-          xrandr --newmode "1280x720_60" 74.50 1280 1344 1472 1664 720 723 728 748 -hsync +vsync 2>/dev/null || true
-          xrandr --addmode default 1280x720_60 2>/dev/null || true
+          xrandr --newmode "1024x768_60" 63.50 1024 1072 1176 1328 768 771 775 798 -hsync +vsync 2>/dev/null || true
+          xrandr --addmode default 1024x768_60 2>/dev/null || true
           echo "DISPLAY=:99" >> $GITHUB_ENV
           echo "LIBGL_ALWAYS_SOFTWARE=true" >> $GITHUB_ENV
           echo "GALLIUM_DRIVER=llvmpipe" >> $GITHUB_ENV

--- a/scripts/ci_helper.py
+++ b/scripts/ci_helper.py
@@ -709,17 +709,26 @@ def run_smoke_test(mc_ver, loader, jdk_ver, mod_jar, headless=True, world_name=N
                                        os.environ.get(f"JAVA_HOME_{jdk_ver}",
                                                        os.environ.get("JAVA_HOME", "")))
 
-    # No -Djava.awt.headless=true: with Xvfb there IS a display, and the
-    # property breaks LWJGL2's X connection on pre-1.13 Minecraft
-    # ("LWJGLException: Could not open X display connection").
-    extra_jvm = ""
+    # -Djava.awt.headless=true is two-sided on Xvfb: LWJGL2 (MC <= 1.12)
+    # fails to open its X display with it ("Could not open X display
+    # connection"), while LWJGL3-era loads benefit (Forge >= 1.20.5 skips
+    # its EarlyDisplay window when AWT is headless). Apply it only to
+    # MC >= 1.13.
+    parts = []
+    try:
+        major = int(mc_ver.split(".")[0])
+    except ValueError:
+        major = 1
+    if major >= 13:
+        parts.append("-Djava.awt.headless=true")
     # Forge >= 1.20.5 opens an early GL window that times out under
     # Xvfb/llvmpipe ("Timed out trying to setup the Game Window");
     # older loaders ignore the property.
     if loader == "forge":
-        extra_jvm += "-Dforge.disableEarlyDisplay=true"
+        parts.append("-Dforge.disableEarlyDisplay=true")
     if world_name:
-        extra_jvm += f" -Dmcp.test.world={world_name}"
+        parts.append(f"-Dmcp.test.world={world_name}")
+    extra_jvm = " ".join(parts)
 
     launcher = str(Path(__file__).resolve().parent.parent / "packages" / "minecraft-mod-mcp" / "dist" / "cli.js")
     try:


### PR DESCRIPTION
Follow-up to #19: dropping `-Djava.awt.headless=true` fixed pre-1.13 but regressed every LWJGL3-era forge lane — Forge's EarlyDisplay only skips its window when AWT is headless. Now the flag applies only to MC >= 1.13 (data-driven: 1.20.4 passed CI with it, 1.12.2 passed WSL without it), forge keeps `-Dforge.disableEarlyDisplay=true`, and the Xvfb screen is aligned to the locally verified 1024x768x24. Push-event lanes verify.