### PR TITLE
🐛 Fix installer processor classpaths and a JPMS module clash.

### DIFF
--- a/packages/minecraft-mod-mcp/src/mc/forgeProcessor.ts
+++ b/packages/minecraft-mod-mcp/src/mc/forgeProcessor.ts
@@ -4,6 +4,7 @@ import { inflateRawSync } from "node:zlib";
 import { spawnSync } from "node:child_process";
 import { librariesDir } from "./platform.js";
 import { DOWNLOAD } from "./defaults.js";
+import { fetchWithFallback } from "./proxy.js";
 
 /**
  * Generic runner for the Forge/NeoForge installer `processors` pipeline.
@@ -106,7 +107,10 @@ async function ensureArtifact(coords: string, ext: string): Promise<string> {
   if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
   if (existsSync(filePath)) return filePath;
 
-  const mvnRel = artifactFilePath(coords, ext).slice(librariesDir().length + 1);
+  const mvnRel = artifactFilePath(coords, ext)
+    .slice(librariesDir().length + 1)
+    .split("\\")
+    .join("/"); // maven URLs are POSIX-shaped even on Windows
   const candidates = [
     `${DOWNLOAD.forgeMavenUrl}${mvnRel}`,
     `${DOWNLOAD.mavenLibrariesUrl}${mvnRel}`,
@@ -114,17 +118,61 @@ async function ensureArtifact(coords: string, ext: string): Promise<string> {
     ...DOWNLOAD.fallbackRepoUrls.map((u) => `${u}${mvnRel}`),
   ];
   for (const url of candidates) {
-    try {
-      const resp = await fetch(url);
-      if (!resp.ok) continue;
-      const ab = Buffer.from(await resp.arrayBuffer());
-      writeFileSync(filePath, ab);
-      return filePath;
-    } catch {
-      /* try next mirror */
+    for (let attempt = 0; attempt < 3; attempt++) {
+      try {
+        const resp = await fetchWithFallback(url);
+        if (!resp.ok) break; // try next mirror
+        const ab = Buffer.from(await resp.arrayBuffer());
+        writeFileSync(filePath, ab);
+        return filePath;
+      } catch {
+        await new Promise((r) => setTimeout(r, 1500 * (attempt + 1)));
+      }
     }
   }
   return filePath; // may not exist yet — likely a processor output
+}
+
+/**
+ * Download an artifact plus the compile-scope dependencies of its POM.
+ * Some installer tools (e.g. NeoForge installertools 2.1.2) rely on
+ * transitive deps like gson that the profile's classpath list omits —
+ * the official installer resolves the POM, so we do one level of it.
+ */
+async function ensureArtifactWithDeps(coords: string, extra: string[]): Promise<void> {
+  let pomPath: string;
+  try {
+    pomPath = await ensureArtifact(coords, "pom");
+  } catch {
+    return;
+  }
+  if (!existsSync(pomPath)) return;
+  let pomText: string;
+  try {
+    pomText = readFileSync(pomPath, "utf-8");
+  } catch {
+    return;
+  }
+  const depRe = /<dependency>([\s\S]*?)<\/dependency>/g;
+  let m: RegExpExecArray | null;
+  while ((m = depRe.exec(pomText)) !== null) {
+    const block = m[1];
+    // Runtime-scope deps ARE needed: the processors are plain JVM mains, so
+    // their "runtime" dependencies (gson, srgutils, ...) belong on the
+    // classpath just like the official installer puts them.
+    if (/<scope>(test|system)<\/scope>/.test(block)) continue;
+    const g = block.match(/<groupId>([^<]+)<\/groupId>/);
+    const a = block.match(/<artifactId>([^<]+)<\/artifactId>/);
+    const v = block.match(/<version>([^<]+)<\/version>/);
+    if (!g || !a || !v) continue;
+    const depCoords = `${g[1]}:${a[1]}:${v[1]}`;
+    try {
+      const depJar = await ensureArtifact(depCoords, DEFAULT_EXT);
+      if (existsSync(depJar)) extra.push(depJar);
+    } catch {
+      /* optional dep — ignore */
+    }
+  }
 }
 
 /** Extract a `/data/…` entry from the installer jar to a stable cache path. */
@@ -202,7 +250,18 @@ export async function runForgeProcessors(
 
     const jarPath = await ensureArtifact(proc.jar, DEFAULT_EXT);
     const cpEntries = [jarPath];
-    for (const cp of proc.classpath ?? []) cpEntries.push(await ensureArtifact(cp, DEFAULT_EXT));
+    const transitiveExtra: string[] = [];
+    for (const cp of proc.classpath ?? []) {
+      // Profile classpath entries carry an "@jar" extension suffix
+      // ("group:artifact:version@jar"); artifactFilePath must not treat it
+      // as part of the version or every download 404s into a bogus
+      // "<version>@jar" directory and the classpath ends up empty.
+      const bareCoords = cp.split("@")[0];
+      const jar = await ensureArtifact(bareCoords, DEFAULT_EXT);
+      cpEntries.push(jar);
+      if (existsSync(jar)) await ensureArtifactWithDeps(bareCoords, transitiveExtra);
+    }
+    cpEntries.push(...new Set(transitiveExtra));
 
     const mainClass = readManifestMainClass(jarPath);
     if (!mainClass) {

--- a/packages/minecraft-mod-mcp/src/mc/launch.ts
+++ b/packages/minecraft-mod-mcp/src/mc/launch.ts
@@ -248,8 +248,15 @@ export function buildLaunchCommand(config: LaunchConfig, vj: VersionJson, data?:
   const classpathPaths = resolveClasspath(vj.libraries);
 
   const inheritsFrom = vj.inheritsFrom ?? versionInfo?.mc_version ?? config.versionId;
+  // Forge 1.17-1.20.4 (bootstraplauncher layout) puts a patched Minecraft on
+  // the module path; adding the vanilla base jar to the classpath as well
+  // creates a second Automatic-Module (_1._17._1) and JPMS aborts with
+  // "Modules ... and minecraft export package net.minecraft...".
+  const bootstrapLayout = (vj.libraries ?? []).some(
+    (l) => typeof l.name === "string" && l.name.startsWith("cpw.mods:bootstraplauncher"),
+  );
   const baseJar = join(versionsDir(), inheritsFrom, `${inheritsFrom}.jar`);
-  if (existsSync(baseJar)) classpathPaths.push(baseJar);
+  if (existsSync(baseJar) && !bootstrapLayout) classpathPaths.push(baseJar);
 
   const versionJar = join(versionsDir(), config.versionId, `${config.versionId}.jar`);
   if (existsSync(versionJar) && versionJar !== baseJar) classpathPaths.push(versionJar);


### PR DESCRIPTION
## Summary

Three root-cause fixes for the remaining smoke failures beyond #20.

1. **`@jar` classpath suffix** (broke 1.20.6/1.21.4-neoforge installs): installer profiles list processor classpath entries as `group:artifact:version@jar`; passing that through verbatim made every dependency resolve into a bogus `<version>@jar` directory, so installertools died with `ClassNotFoundException: gson`. Strip the suffix before resolving — verified locally: 1.20.6-neoforge now installs end to end.
2. **Windows maven URLs + one-shot fetch**: `ensureArtifact` built backslash URLs (every download 404'd/failed on Windows) and used a bare `fetch` with no retry; now POSIX-shaped paths through `fetchWithFallback` with retries.
3. **JPMS module clash** (1.17–1.20.4 forge): bootstraplauncher layouts put patched Minecraft on the module path; adding the vanilla base jar to the classpath created a second Automatic-Module (`_1._17._1`) and the JVM aborted with `ResolutionException`. Skip the base jar when the profile carries `cpw.mods:bootstraplauncher` (verified present in 1.17.1/1.18.2/1.19.4 profiles).
4. Bonus: one level of POM dependency resolution (runtime scope included) for processor tools with incomplete profile classpaths.

## Tested

- [x] Local: 1.20.6-neoforge CLI install now completes (`install complete`), 19 stale `@jar` directories cleaned.
- [x] bootstraplauncher detection verified against installed 1.17.1/1.18.2/1.19.4 profiles.
- [x] tsc + build clean.
- [ ] Master pipeline after merge.