### PR TITLE
🐛 Recognize forge-style NeoForge installs and restore the Xvfb mode.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -421,10 +421,10 @@ jobs:
           sudo apt-get install -y -qq xvfb libgl1-mesa-glx libgl1-mesa-dri libx11-dev x11-xserver-utils 2>/dev/null || true
       - name: Start Xvfb
         run: |
-          Xvfb :99 -screen 0 1024x768x24 -ac +extension RANDR +extension GLX -nolisten tcp &
+          Xvfb :99 -screen 0 1280x720x24 -ac +extension RANDR +extension GLX -nolisten tcp &
           sleep 2
-          xrandr --newmode "1024x768_60" 63.50 1024 1072 1176 1328 768 771 775 798 -hsync +vsync 2>/dev/null || true
-          xrandr --addmode default 1024x768_60 2>/dev/null || true
+          xrandr --newmode "1280x720_60" 74.50 1280 1344 1472 1664 720 723 728 748 -hsync +vsync 2>/dev/null || true
+          xrandr --addmode default 1280x720_60 2>/dev/null || true
           echo "DISPLAY=:99" >> $GITHUB_ENV
           echo "LIBGL_ALWAYS_SOFTWARE=true" >> $GITHUB_ENV
           echo "GALLIUM_DRIVER=llvmpipe" >> $GITHUB_ENV
@@ -506,10 +506,10 @@ jobs:
           sudo apt-get install -y -qq xvfb libgl1-mesa-glx libgl1-mesa-dri x11-xserver-utils 2>/dev/null || true
       - name: Start Xvfb
         run: |
-          Xvfb :99 -screen 0 1024x768x24 -ac +extension RANDR +extension GLX -nolisten tcp &
+          Xvfb :99 -screen 0 1280x720x24 -ac +extension RANDR +extension GLX -nolisten tcp &
           sleep 2
-          xrandr --newmode "1024x768_60" 63.50 1024 1072 1176 1328 768 771 775 798 -hsync +vsync 2>/dev/null || true
-          xrandr --addmode default 1024x768_60 2>/dev/null || true
+          xrandr --newmode "1280x720_60" 74.50 1280 1344 1472 1664 720 723 728 748 -hsync +vsync 2>/dev/null || true
+          xrandr --addmode default 1280x720_60 2>/dev/null || true
           echo "DISPLAY=:99" >> $GITHUB_ENV
           echo "LIBGL_ALWAYS_SOFTWARE=true" >> $GITHUB_ENV
           echo "GALLIUM_DRIVER=llvmpipe" >> $GITHUB_ENV
@@ -584,10 +584,10 @@ jobs:
           sudo apt-get install -y -qq xvfb libgl1-mesa-glx libgl1-mesa-dri x11-xserver-utils 2>/dev/null || true
       - name: Start Xvfb
         run: |
-          Xvfb :99 -screen 0 1024x768x24 -ac +extension RANDR +extension GLX -nolisten tcp &
+          Xvfb :99 -screen 0 1280x720x24 -ac +extension RANDR +extension GLX -nolisten tcp &
           sleep 2
-          xrandr --newmode "1024x768_60" 63.50 1024 1072 1176 1328 768 771 775 798 -hsync +vsync 2>/dev/null || true
-          xrandr --addmode default 1024x768_60 2>/dev/null || true
+          xrandr --newmode "1280x720_60" 74.50 1280 1344 1472 1664 720 723 728 748 -hsync +vsync 2>/dev/null || true
+          xrandr --addmode default 1280x720_60 2>/dev/null || true
           echo "DISPLAY=:99" >> $GITHUB_ENV
           echo "LIBGL_ALWAYS_SOFTWARE=true" >> $GITHUB_ENV
           echo "GALLIUM_DRIVER=llvmpipe" >> $GITHUB_ENV

--- a/scripts/ci_helper.py
+++ b/scripts/ci_helper.py
@@ -191,7 +191,9 @@ def _find_installed(mc_ver: str, loader: str, mc_dir: str | None = None) -> str 
         if inherits != mc_ver:
             continue
         mc_cls = (data.get("mainClass") or "").lower()
-        if loader_lower == "neoforge" and "neoforged" in mc_cls:
+        # 20.6.x-era NeoForge ships a forge-style BootstrapLauncher
+        # mainClass, so also accept the conventional directory name.
+        if loader_lower == "neoforge" and ("neoforged" in mc_cls or d.name.lower().startswith("neoforge")):
             return d.name
         if loader_lower == "forge" and ("minecraftforge" in mc_cls or "forgebootstrap" in mc_cls
                                         or "launchwrapper" in mc_cls or "bootstraplauncher" in mc_cls


### PR DESCRIPTION
Two follow-ups to #21: (1) NeoForge 20.6.x installs with a forge-style BootstrapLauncher mainClass, so the helper's mainClass detection flagged the freshly installed 20.6.134 as missing — also accept the conventional `neoforge-*` directory name; (2) the 1024x768 Xvfb screen regressed the EarlyDisplay lanes that were green at 1280x720 — restore the verified mode. Push-event lanes verify.