### PR TITLE
🐛 Improve external client status and input handling.

### DIFF
--- a/docs/guides/en/AI-TOOLS.md
+++ b/docs/guides/en/AI-TOOLS.md
@@ -140,6 +140,8 @@ Minecraft is a GUI app. To run it on a headless Linux box you need one of:
 
 If `launch_minecraft` fails with a display/AWT error, set `DISPLAY` or wrap the launch in `xvfb-run`. The bridge inherits your environment, so `export DISPLAY=:0` (or running inside an XFCE session) is usually all that's needed.
 
+For native Wayland sessions, compositor-targeted input, external Prism instances, and process diagnostics, see the **[Wayland and Hyprland guide](./WAYLAND.md)**.
+
 ---
 
 ## Launching Minecraft

--- a/docs/guides/en/WAYLAND.md
+++ b/docs/guides/en/WAYLAND.md
@@ -1,0 +1,198 @@
+# Wayland and Hyprland Troubleshooting
+
+This guide covers practical issues found while controlling Minecraft Mod MCP
+on a native Wayland desktop. Commands use Hyprland, Prism Launcher, and Linux,
+but the process and input caveats apply to other Wayland compositors and
+external launchers.
+
+## Verify the client with multiple signals
+
+`get_minecraft_status().processAlive` reports whether a process started by
+this bridge is alive. It is expected to be `false` when Minecraft was launched
+by Prism or another external launcher. In that case, use `connected` together
+with the reported mod `pid`.
+
+The status tool probes the selected mod port before responding and clears a
+stale connection after a failed heartbeat. Still verify an external client
+with several independent signals when diagnosing launcher or compositor
+problems:
+
+1. Find the real Java PID.
+2. Confirm the PID with `ps`.
+3. Call `ping`.
+4. Read `get_player_info`.
+5. Capture a screenshot or inspect the current GUI.
+6. Check that Minecraft's `latest.log` has current timestamps.
+
+The status result includes the mod's real `pid`, `uptime`, `version`, and
+`loader`. Prefer those values over matching the first Java process on the
+machine.
+
+## Find the Wayland window
+
+Wayland does not expose X11-style global window control. Under Hyprland, use
+compositor IPC:
+
+```bash
+hyprctl clients -j | jq -c '.[] | {
+  address, pid, class, title, workspace, focusHistoryID
+}'
+```
+
+Minecraft's window class may be empty during startup or in some LWJGL states.
+Match both PID and title. Re-resolve them after every restart, because stale
+Prism and Java processes may coexist.
+
+Do not select the first process named `java`; Gradle daemons and dedicated
+servers are Java processes too. One useful diagnostic is:
+
+```bash
+ps -eo pid,ppid,stat,lstart,cmd | rg \
+  '/java.*(org\.prismlauncher\.EntryPoint|minecraft)'
+```
+
+## Understand Prism's process model
+
+Prism is normally single-instance. A new AppImage invocation can forward a
+launch request to an existing Prism process and then exit. The existing Prism
+process creates the Java child.
+
+This has several consequences:
+
+- `$!` from the AppImage command may not be Minecraft's PID.
+- Waiting on the AppImage invocation may not capture Minecraft's exit status.
+- Redirected AppImage output may contain only Qt frontend warnings.
+- You must discover and monitor the new Java child after launch.
+
+For example:
+
+```bash
+PrismLauncher.AppImage --appimage-extract-and-run \
+  --launch "INSTANCE_ID" --server example.invalid
+```
+
+This warning concerns Prism's Qt frontend and does not by itself prove a
+Minecraft or LWJGL failure:
+
+```text
+qt.qpa.plugin: Could not find the Qt platform plugin "wayland"
+```
+
+Prism may run through XWayland while Minecraft uses a separate GLFW window.
+
+## Know what `press_key` injects
+
+On modern Minecraft versions, `press_key` invokes Minecraft's keyboard
+handler inside the process. It is not an operating-system keyboard event.
+This works for normal game input but may not trigger every loader-specific or
+native GLFW event listener used by another mod.
+
+If a test specifically needs a compositor-level key event, Hyprland `0.56`
+can target the current Minecraft PID:
+
+```bash
+hyprctl dispatch \
+  'hl.dsp.send_key_state({mods="", key="Up", state="down", window="pid:PID"})'
+sleep 0.2
+hyprctl dispatch \
+  'hl.dsp.send_key_state({mods="", key="Up", state="up", window="pid:PID"})'
+```
+
+This is an advanced fallback, not part of Minecraft Mod MCP. Hyprland command
+syntax differs between versions.
+
+When using it:
+
+- Always send distinct down and up edges.
+- Never reuse a PID after restart.
+- Log the target PID and each injected edge.
+- Confirm exactly one resulting state transition in the game log.
+- Do not mix compositor injection with a queued `KeyMapping.consumeClick()`
+  toggle unless repeated activation is intended.
+
+## Separate cursor release, control mode, and focus behavior
+
+These are different states:
+
+- `release_mouse` releases GLFW's cursor grab.
+- MCP control mode enables MCP click, type, and keyboard tools.
+- Minecraft's pause-on-focus-loss setting controls behavior after changing
+  windows or workspaces.
+
+Releasing the cursor does not itself change Minecraft's pause-on-focus-loss
+option. Automation that requires client ticks while unfocused must account for
+that separately in the tested mod or Minecraft configuration.
+
+Use control mode only while needed. Status, player state, world state, and
+screenshots are safer for passive observation. GUI and keyboard actions may
+require control mode and should be followed by server-authoritative
+confirmation rather than assuming the local click already changed inventory.
+
+## Switch workspaces safely
+
+Inspect current workspace and Minecraft placement before a test:
+
+```bash
+hyprctl activeworkspace -j
+hyprctl clients -j | jq -c \
+  '.[] | select(.pid == PID) | {pid,title,workspace}'
+```
+
+When the test only needs focus loss, prefer a semantic compositor dispatch:
+
+```bash
+hyprctl dispatch 'hl.dsp.focus({workspace=2})'
+```
+
+This avoids leaking `Super` or number-key state into Minecraft. Use the real
+`Super + number` shortcut only when reproducing keyboard-routing behavior.
+
+After switching, verify the same Java PID, call `ping` and `get_player_info`,
+and check the game log for unexpected key actions. If an automation toggle
+changes state immediately before exit, investigate input routing before
+classifying the event as a Wayland rendering crash.
+
+## Diagnose abrupt exits
+
+Minecraft logs cannot explain every external `SIGTERM` or `SIGKILL`. Check all
+available layers around the failure time:
+
+```bash
+journalctl --since 'TIME-1min' --until 'TIME+1min' --no-pager
+journalctl -k --since 'TIME-1min' --until 'TIME+1min' --no-pager
+coredumpctl list --no-pager
+```
+
+Also inspect:
+
+- Minecraft `logs/latest.log`
+- Minecraft `logs/debug.log`
+- Prism launcher logs and captured game console
+- `hs_err_pid*.log`
+- compositor logs
+
+Typical interpretations:
+
+- Java stack trace or loader crash report: game or mod failure.
+- `hs_err_pid` file or coredump: JVM, native library, or LWJGL failure.
+- kernel OOM entry: memory-pressure kill.
+- clean log ending without a shutdown sequence: likely external signal.
+- mod stop or toggle immediately before exit: likely input or application
+  behavior rather than a compositor crash.
+
+When Prism was already running, monitor the discovered Java child directly;
+the forwarding AppImage command cannot provide the game's exit status.
+
+## Test checklist
+
+1. Record compositor, launcher, Minecraft, loader, mod, and Java versions.
+2. Launch the intended instance.
+3. Discover fresh `/api/status` PID and Hyprland window address.
+4. Confirm PID, `ping`, player state, screenshot, and current log timestamps.
+5. Enter control mode only if the requested action requires it.
+6. Inject one explicit key action and confirm one result.
+7. Test semantic workspace switching before real shortcut injection.
+8. Re-check PID, MCP calls, and logs after focus changes.
+9. Preserve all logs before relaunching after a failure.
+10. Never include accounts, access tokens, private server addresses, or chat
+    contents in bug reports.

--- a/packages/common/src/main/java/xyz/langyo/minecraft/mcp/common/GlfwKeys.java
+++ b/packages/common/src/main/java/xyz/langyo/minecraft/mcp/common/GlfwKeys.java
@@ -13,8 +13,11 @@ public final class GlfwKeys {
     public static final int KEY_LEFT = 0xFF51;
     public static final int KEY_RIGHT = 0xFF53;
     public static final int KEY_LEFT_SHIFT = 0xFFE1;
+    public static final int KEY_RIGHT_SHIFT = 0xFFE2;
     public static final int KEY_LEFT_CONTROL = 0xFFE3;
+    public static final int KEY_RIGHT_CONTROL = 0xFFE4;
     public static final int KEY_LEFT_ALT = 0xFFE9;
+    public static final int KEY_RIGHT_ALT = 0xFFEA;
     public static final int KEY_F1 = 0xFFBE;
     public static final int KEY_A = 0x0041;
     public static final int KEY_0 = 0x0030;
@@ -31,8 +34,11 @@ public final class GlfwKeys {
     private static int GLFW_KEY_LEFT_R;
     private static int GLFW_KEY_RIGHT_R;
     private static int GLFW_KEY_LEFT_SHIFT_R;
+    private static int GLFW_KEY_RIGHT_SHIFT_R;
     private static int GLFW_KEY_LEFT_CONTROL_R;
+    private static int GLFW_KEY_RIGHT_CONTROL_R;
     private static int GLFW_KEY_LEFT_ALT_R;
+    private static int GLFW_KEY_RIGHT_ALT_R;
     private static int GLFW_KEY_F1_R;
     private static int GLFW_KEY_A_R;
     private static int GLFW_KEY_0_R;
@@ -62,8 +68,11 @@ public final class GlfwKeys {
             GLFW_KEY_LEFT_R = (int) glfw.getField("GLFW_KEY_LEFT").get(null);
             GLFW_KEY_RIGHT_R = (int) glfw.getField("GLFW_KEY_RIGHT").get(null);
             GLFW_KEY_LEFT_SHIFT_R = (int) glfw.getField("GLFW_KEY_LEFT_SHIFT").get(null);
+            GLFW_KEY_RIGHT_SHIFT_R = (int) glfw.getField("GLFW_KEY_RIGHT_SHIFT").get(null);
             GLFW_KEY_LEFT_CONTROL_R = (int) glfw.getField("GLFW_KEY_LEFT_CONTROL").get(null);
+            GLFW_KEY_RIGHT_CONTROL_R = (int) glfw.getField("GLFW_KEY_RIGHT_CONTROL").get(null);
             GLFW_KEY_LEFT_ALT_R = (int) glfw.getField("GLFW_KEY_LEFT_ALT").get(null);
+            GLFW_KEY_RIGHT_ALT_R = (int) glfw.getField("GLFW_KEY_RIGHT_ALT").get(null);
             GLFW_KEY_F1_R = (int) glfw.getField("GLFW_KEY_F1").get(null);
             GLFW_KEY_A_R = (int) glfw.getField("GLFW_KEY_A").get(null);
             GLFW_KEY_0_R = (int) glfw.getField("GLFW_KEY_0").get(null);
@@ -82,6 +91,7 @@ public final class GlfwKeys {
 
     public static int keyCode(String name) {
         String n = name.toLowerCase();
+        if (n.startsWith("key.keyboard.")) n = n.substring("key.keyboard.".length());
         resolve();
         if (ReflectionHelper.isLwjgl3()) {
             return resolveGlfw(n);
@@ -108,9 +118,12 @@ public final class GlfwKeys {
         if (n.equals("down")) return GLFW_KEY_DOWN_R;
         if (n.equals("left")) return GLFW_KEY_LEFT_R;
         if (n.equals("right")) return GLFW_KEY_RIGHT_R;
-        if (n.equals("shift")) return GLFW_KEY_LEFT_SHIFT_R;
-        if (n.equals("ctrl") || n.equals("control")) return GLFW_KEY_LEFT_CONTROL_R;
-        if (n.equals("alt")) return GLFW_KEY_LEFT_ALT_R;
+        if (n.equals("shift") || n.equals("left shift") || n.equals("left.shift")) return GLFW_KEY_LEFT_SHIFT_R;
+        if (n.equals("right shift") || n.equals("right.shift")) return GLFW_KEY_RIGHT_SHIFT_R;
+        if (n.equals("ctrl") || n.equals("control") || n.equals("left control") || n.equals("left.control")) return GLFW_KEY_LEFT_CONTROL_R;
+        if (n.equals("right control") || n.equals("right.control")) return GLFW_KEY_RIGHT_CONTROL_R;
+        if (n.equals("alt") || n.equals("left alt") || n.equals("left.alt")) return GLFW_KEY_LEFT_ALT_R;
+        if (n.equals("right alt") || n.equals("right.alt")) return GLFW_KEY_RIGHT_ALT_R;
         if (n.startsWith("f") && n.length() >= 2) {
             try {
                 int fn = Integer.parseInt(n.substring(1));
@@ -121,15 +134,6 @@ public final class GlfwKeys {
             char c = n.charAt(0);
             if (c >= 'a' && c <= 'z') return GLFW_KEY_A_R + (c - 'a');
             if (c >= '0' && c <= '9') return GLFW_KEY_0_R + (c - '0');
-        }
-        if (n.startsWith("key.keyboard.")) {
-            String suffix = n.substring("key.keyboard.".length());
-            if (suffix.length() == 1) {
-                char c = suffix.charAt(0);
-                if (c >= '0' && c <= '9') return GLFW_KEY_0_R + (c - '0');
-                if (c >= 'a' && c <= 'z') return GLFW_KEY_A_R + (c - 'a');
-                if (c >= 'A' && c <= 'Z') return GLFW_KEY_A_R + (c - 'A');
-            }
         }
         return -1;
     }
@@ -145,9 +149,12 @@ public final class GlfwKeys {
         if (n.equals("down")) return KEY_DOWN;
         if (n.equals("left")) return KEY_LEFT;
         if (n.equals("right")) return KEY_RIGHT;
-        if (n.equals("shift")) return KEY_LEFT_SHIFT;
-        if (n.equals("ctrl") || n.equals("control")) return KEY_LEFT_CONTROL;
-        if (n.equals("alt")) return KEY_LEFT_ALT;
+        if (n.equals("shift") || n.equals("left shift") || n.equals("left.shift")) return KEY_LEFT_SHIFT;
+        if (n.equals("right shift") || n.equals("right.shift")) return KEY_RIGHT_SHIFT;
+        if (n.equals("ctrl") || n.equals("control") || n.equals("left control") || n.equals("left.control")) return KEY_LEFT_CONTROL;
+        if (n.equals("right control") || n.equals("right.control")) return KEY_RIGHT_CONTROL;
+        if (n.equals("alt") || n.equals("left alt") || n.equals("left.alt")) return KEY_LEFT_ALT;
+        if (n.equals("right alt") || n.equals("right.alt")) return KEY_RIGHT_ALT;
         if (n.startsWith("f") && n.length() >= 2) {
             try {
                 int fn = Integer.parseInt(n.substring(1));
@@ -157,15 +164,7 @@ public final class GlfwKeys {
         if (n.length() == 1) {
             char c = n.charAt(0);
             if (c >= 'a' && c <= 'z') return KEY_A + (c - 'a');
-        }
-        if (n.startsWith("key.keyboard.")) {
-            String suffix = n.substring("key.keyboard.".length());
-            if (suffix.length() == 1) {
-                char c = suffix.charAt(0);
-                if (c >= '0' && c <= '9') return KEY_0 + (c - '0');
-                if (c >= 'a' && c <= 'z') return KEY_A + (c - 'a');
-                if (c >= 'A' && c <= 'Z') return KEY_A + (c - 'A');
-            }
+            if (c >= '0' && c <= '9') return KEY_0 + (c - '0');
         }
         return -1;
     }

--- a/packages/common/src/main/java/xyz/langyo/minecraft/mcp/common/InputInjectionHelper.java
+++ b/packages/common/src/main/java/xyz/langyo/minecraft/mcp/common/InputInjectionHelper.java
@@ -20,15 +20,11 @@ public final class InputInjectionHelper {
                 Object mc = ReflectionCache.getMinecraftInstance();
                 Object kbHandler = getKeyboardHandler(mc);
                 if (kbHandler != null) {
-                    for (java.lang.reflect.Method m : kbHandler.getClass().getDeclaredMethods()) {
-                        Class<?>[] pts = m.getParameterTypes();
-                        if (pts.length == 5 && pts[0] == long.class && pts[1] == int.class
-                                && pts[2] == int.class && pts[3] == int.class && pts[4] == int.class
-                                && !java.lang.reflect.Modifier.isStatic(m.getModifiers())) {
-                            m.setAccessible(true);
-                            m.invoke(kbHandler, handle, key, 0, action, 0);
-                            return;
-                        }
+                    java.lang.reflect.Method method = findKeyboardMethod(kbHandler.getClass());
+                    if (method != null) {
+                        method.setAccessible(true);
+                        method.invoke(kbHandler, handle, key, 0, action, 0);
+                        return;
                     }
                 }
             } catch (Exception e) {
@@ -56,6 +52,23 @@ public final class InputInjectionHelper {
             }
         }
         return null;
+    }
+
+    private static java.lang.reflect.Method findKeyboardMethod(Class<?> type) {
+        java.lang.reflect.Method named = null;
+        java.lang.reflect.Method fallback = null;
+        boolean ambiguous = false;
+        for (java.lang.reflect.Method method : ReflectionCache.getAllMethods(type)) {
+            if (method.isSynthetic() || method.isBridge()) continue;
+            Class<?>[] pts = method.getParameterTypes();
+            if (pts.length != 5 || pts[0] != long.class || pts[1] != int.class
+                    || pts[2] != int.class || pts[3] != int.class || pts[4] != int.class
+                    || java.lang.reflect.Modifier.isStatic(method.getModifiers())) continue;
+            if (method.getName().equals("keyPress")) named = method;
+            else if (fallback == null) fallback = method;
+            else ambiguous = true;
+        }
+        return named != null ? named : ambiguous ? null : fallback;
     }
 
     private static Object getMouseHandlerField(Object mc) {
@@ -275,6 +288,9 @@ public final class InputInjectionHelper {
     private static int glfwToAwt(int glfwKey) {
         if (glfwKey >= 'A' && glfwKey <= 'Z') return KeyEvent.VK_A + (glfwKey - 'A');
         if (glfwKey >= '0' && glfwKey <= '9') return KeyEvent.VK_0 + (glfwKey - '0');
+        if (glfwKey == GlfwKeys.keyCode("left.shift") || glfwKey == GlfwKeys.keyCode("right.shift")) return KeyEvent.VK_SHIFT;
+        if (glfwKey == GlfwKeys.keyCode("left.control") || glfwKey == GlfwKeys.keyCode("right.control")) return KeyEvent.VK_CONTROL;
+        if (glfwKey == GlfwKeys.keyCode("left.alt") || glfwKey == GlfwKeys.keyCode("right.alt")) return KeyEvent.VK_ALT;
         switch (glfwKey) {
             case 0xFF0D: return KeyEvent.VK_ENTER;
             case 0xFF1B: return KeyEvent.VK_ESCAPE;

--- a/packages/common/src/main/java/xyz/langyo/minecraft/mcp/common/InputInjectionHelper.java
+++ b/packages/common/src/main/java/xyz/langyo/minecraft/mcp/common/InputInjectionHelper.java
@@ -23,7 +23,14 @@ public final class InputInjectionHelper {
                     java.lang.reflect.Method method = findKeyboardMethod(kbHandler.getClass());
                     if (method != null) {
                         method.setAccessible(true);
-                        method.invoke(kbHandler, handle, key, 0, action, 0);
+                        if (method.getParameterCount() == 5) {
+                            method.invoke(kbHandler, handle, key, 0, action, 0);
+                        } else {
+                            java.lang.reflect.Constructor<?> constructor = method.getParameterTypes()[2]
+                                    .getDeclaredConstructor(int.class, int.class, int.class);
+                            constructor.setAccessible(true);
+                            method.invoke(kbHandler, handle, action, constructor.newInstance(key, 0, 0));
+                        }
                         return;
                     }
                 }
@@ -54,16 +61,18 @@ public final class InputInjectionHelper {
         return null;
     }
 
-    private static java.lang.reflect.Method findKeyboardMethod(Class<?> type) {
+    static java.lang.reflect.Method findKeyboardMethod(Class<?> type) {
         java.lang.reflect.Method named = null;
         java.lang.reflect.Method fallback = null;
         boolean ambiguous = false;
         for (java.lang.reflect.Method method : ReflectionCache.getAllMethods(type)) {
             if (method.isSynthetic() || method.isBridge()) continue;
             Class<?>[] pts = method.getParameterTypes();
-            if (pts.length != 5 || pts[0] != long.class || pts[1] != int.class
-                    || pts[2] != int.class || pts[3] != int.class || pts[4] != int.class
-                    || java.lang.reflect.Modifier.isStatic(method.getModifiers())) continue;
+            boolean legacy = pts.length == 5 && pts[0] == long.class && pts[1] == int.class
+                    && pts[2] == int.class && pts[3] == int.class && pts[4] == int.class;
+            boolean modern = pts.length == 3 && pts[0] == long.class && pts[1] == int.class
+                    && !pts[2].isPrimitive();
+            if ((!legacy && !modern) || java.lang.reflect.Modifier.isStatic(method.getModifiers())) continue;
             if (method.getName().equals("keyPress")) named = method;
             else if (fallback == null) fallback = method;
             else ambiguous = true;

--- a/packages/common/src/main/java/xyz/langyo/minecraft/mcp/common/McpHttpServer.java
+++ b/packages/common/src/main/java/xyz/langyo/minecraft/mcp/common/McpHttpServer.java
@@ -74,13 +74,13 @@ public class McpHttpServer {
     public void start() throws IOException {
         int configuredPort = this.port;
         if (configuredPort > 0) {
-            server = HttpServer.create(new InetSocketAddress("0.0.0.0", configuredPort), 0);
+            server = HttpServer.create(new InetSocketAddress("127.0.0.1", configuredPort), 0);
             port = configuredPort;
         } else {
             IOException lastErr = null;
             for (int p = PORT_START; p >= PORT_END; p--) {
                 try {
-                    server = HttpServer.create(new InetSocketAddress("0.0.0.0", p), 0);
+                    server = HttpServer.create(new InetSocketAddress("127.0.0.1", p), 0);
                     port = p;
                     lastErr = null;
                     break;

--- a/packages/common/src/main/java/xyz/langyo/minecraft/mcp/common/ReflectedInputHandler.java
+++ b/packages/common/src/main/java/xyz/langyo/minecraft/mcp/common/ReflectedInputHandler.java
@@ -2,12 +2,25 @@ package xyz.langyo.minecraft.mcp.common;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 
 public class ReflectedInputHandler extends McpMessageHandler implements McpProtocol.MinecraftInput {
 
     private final RenderThreadExecutor executor;
+    private final ScheduledExecutorService keyReleaser = Executors.newSingleThreadScheduledExecutor(r -> {
+        Thread thread = new Thread(r, "mcp-key-release");
+        thread.setDaemon(true);
+        return thread;
+    });
+    private final ConcurrentHashMap<Integer, Long> keyPresses = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<Integer, ScheduledFuture<?>> keyReleases = new ConcurrentHashMap<>();
+    private final AtomicLong keyPressSequence = new AtomicLong();
 
     public ReflectedInputHandler(RenderThreadExecutor executor) {
         super();
@@ -149,15 +162,30 @@ public class ReflectedInputHandler extends McpMessageHandler implements McpProto
     @Override
     public void pressKey(String key, float holdSeconds) {
         executor.executeOnRenderThread(() -> {
-            try {
-                int c = GlfwKeys.keyCode(key);
-                if (c < 0) return;
-                String result = ReflectionHelper.guiKeyPress(mc(), c, 0, 1, 0);
-                ReflectionHelper.dbg("guiKeyPress: " + result);
-                Thread.sleep(holdSeconds > 0 ? (long)(holdSeconds * 1000) : 30);
-                result = ReflectionHelper.guiKeyPress(mc(), c, 0, 0, 0);
-                ReflectionHelper.dbg("guiKeyPress release: " + result);
-            } catch (Exception e) { System.err.println("[Input] Key: " + e.getMessage()); }
+            int c = GlfwKeys.keyCode(key);
+            if (c < 0) {
+                System.err.println("[Input] Unknown key: " + key);
+                return;
+            }
+            if (!ReflectionHelper.isLwjgl3()) {
+                try {
+                    ReflectionHelper.guiKeyPress(mc(), c, 0, 1, 0);
+                    Thread.sleep(holdSeconds > 0 ? (long)(holdSeconds * 1000) : 30);
+                    ReflectionHelper.guiKeyPress(mc(), c, 0, 0, 0);
+                } catch (Exception e) { System.err.println("[Input] Key: " + e.getMessage()); }
+                return;
+            }
+            ReflectionHelper.sendKey(getWindowHandle(), c, 1);
+            long sequence = keyPressSequence.incrementAndGet();
+            keyPresses.put(c, sequence);
+            long delay = holdSeconds > 0 ? (long)(holdSeconds * 1000) : 30;
+            ScheduledFuture<?> release = keyReleaser.schedule(() -> {
+                executor.executeOnRenderThread(() -> {
+                    if (keyPresses.remove(c, sequence)) ReflectionHelper.sendKey(getWindowHandle(), c, 0);
+                });
+            }, delay, TimeUnit.MILLISECONDS);
+            ScheduledFuture<?> previous = keyReleases.put(c, release);
+            if (previous != null) previous.cancel(false);
         });
     }
 
@@ -226,6 +254,16 @@ public class ReflectedInputHandler extends McpMessageHandler implements McpProto
                 if (h == 0) return;
                 int[] codes = new int[keys.length];
                 for (int i = 0; i < keys.length; i++) codes[i] = GlfwKeys.keyCode(keys[i]);
+                for (int c : codes) {
+                    if (c < 0) {
+                        System.err.println("[Input] Unknown hotkey");
+                        return;
+                    }
+                    if (keyPresses.containsKey(c)) {
+                        System.err.println("[Input] Hotkey contains a held key");
+                        return;
+                    }
+                }
                 for (int c : codes) { ReflectionHelper.sendKey(h, c, 1); Thread.sleep(5); }
                 Thread.sleep(80);
                 for (int i = codes.length - 1; i >= 0; i--) ReflectionHelper.sendKey(h, codes[i], 0);

--- a/packages/common/src/main/java/xyz/langyo/minecraft/mcp/common/ReflectionCache.java
+++ b/packages/common/src/main/java/xyz/langyo/minecraft/mcp/common/ReflectionCache.java
@@ -244,9 +244,11 @@ public final class ReflectionCache {
     static boolean isKeyboardHandlerType(Class<?> clazz) {
         for (Method m : getAllMethods(clazz)) {
             Class<?>[] pts = m.getParameterTypes();
-            if (pts.length == 5 && pts[0] == long.class && pts[1] == int.class
-                    && pts[2] == int.class && pts[3] == int.class && pts[4] == int.class
-                    && !Modifier.isStatic(m.getModifiers())) return true;
+            boolean legacy = pts.length == 5 && pts[0] == long.class && pts[1] == int.class
+                    && pts[2] == int.class && pts[3] == int.class && pts[4] == int.class;
+            boolean modern = pts.length == 3 && pts[0] == long.class && pts[1] == int.class
+                    && !pts[2].isPrimitive();
+            if ((legacy || modern) && !Modifier.isStatic(m.getModifiers())) return true;
         }
         return false;
     }

--- a/packages/common/src/main/java/xyz/langyo/minecraft/mcp/common/ScreenInteractionHelper.java
+++ b/packages/common/src/main/java/xyz/langyo/minecraft/mcp/common/ScreenInteractionHelper.java
@@ -1242,15 +1242,20 @@ public final class ScreenInteractionHelper {
                 try { kbHandler = mc.getClass().getMethod("keyboardHandler").invoke(mc); } catch (Exception ignored) {}
             }
             if (kbHandler != null) {
-                for (Method m : kbHandler.getClass().getDeclaredMethods()) {
-                    if (m.getName().equals("keyPress") && m.getParameterCount() == 5) {
-                        long handle = 0;
-                        try { handle = WindowHelper.getWindowHandle(mc); } catch (Exception ignored) {}
+                Method m = InputInjectionHelper.findKeyboardMethod(kbHandler.getClass());
+                if (m != null) {
+                    long handle = WindowHelper.getWindowHandle(mc);
+                    m.setAccessible(true);
+                    if (m.getParameterCount() == 5) {
                         ReflectionHelper.dbg("guiKeyPress: keyPress(" + handle + "," + keyCode + "," + scanCode + "," + action + "," + modifiers + ") kb=" + kbHandler.getClass().getSimpleName());
-                        m.setAccessible(true);
                         m.invoke(kbHandler, handle, keyCode, scanCode, action, modifiers);
                         return "{\"keyPressed\":true,\"via\":\"keyboardHandler\"}";
                     }
+                    java.lang.reflect.Constructor<?> constructor = m.getParameterTypes()[2]
+                            .getDeclaredConstructor(int.class, int.class, int.class);
+                    constructor.setAccessible(true);
+                    m.invoke(kbHandler, handle, action, constructor.newInstance(keyCode, scanCode, modifiers));
+                    return "{\"keyPressed\":true,\"via\":\"keyboardHandler.event\"}";
                 }
             }
             return "{\"error\":\"no key input method found\"}";
@@ -1300,6 +1305,29 @@ public final class ScreenInteractionHelper {
             }
             if (kbHandler != null) {
                 long handle = WindowHelper.getWindowHandle(mc);
+                Method eventMethod = null;
+                Method fallback = null;
+                boolean ambiguous = false;
+                for (Method m : ReflectionCache.getAllMethods(kbHandler.getClass())) {
+                    if (m.isSynthetic() || m.isBridge() || java.lang.reflect.Modifier.isStatic(m.getModifiers())) continue;
+                    Class<?>[] pt = m.getParameterTypes();
+                    if (pt.length == 2 && pt[0] == long.class && !pt[1].isPrimitive()) {
+                        try { pt[1].getDeclaredConstructor(int.class, int.class); }
+                        catch (NoSuchMethodException ignored) { continue; }
+                        if (m.getName().equals("charTyped")) eventMethod = m;
+                        else if (fallback == null) fallback = m;
+                        else ambiguous = true;
+                    }
+                }
+                if (eventMethod == null && !ambiguous) eventMethod = fallback;
+                if (eventMethod != null) {
+                    java.lang.reflect.Constructor<?> constructor = eventMethod.getParameterTypes()[1]
+                            .getDeclaredConstructor(int.class, int.class);
+                    constructor.setAccessible(true);
+                    eventMethod.setAccessible(true);
+                    eventMethod.invoke(kbHandler, handle, constructor.newInstance((int) ch, modifiers));
+                    return "{\"charTyped\":true,\"via\":\"kb.event\"}";
+                }
                 for (Method m : kbHandler.getClass().getDeclaredMethods()) {
                     String n = m.getName();
                     if (m.getParameterCount() >= 2 && m.getParameterTypes()[0] == long.class

--- a/packages/minecraft-mod-mcp/package.json
+++ b/packages/minecraft-mod-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minecraft-mod-mcp",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "MCP server bridge & launcher CLI for Minecraft — connect AI tools to Minecraft via Model Context Protocol, launch and manage instances",
   "type": "module",
   "main": "dist/index.cjs",

--- a/packages/minecraft-mod-mcp/src/api/http.ts
+++ b/packages/minecraft-mod-mcp/src/api/http.ts
@@ -11,6 +11,7 @@ export function createApiApp(mod: ModClient): Server {
 
     try {
       if (req.method === "GET" && path === "/api/status") {
+        await mod.checkAlive();
         const rt = typeof (globalThis as any).Deno !== "undefined" ? "deno" : typeof (globalThis as any).Bun !== "undefined" ? "bun" : "node";
         res.end(JSON.stringify({
           ok: true,
@@ -28,8 +29,14 @@ export function createApiApp(mod: ModClient): Server {
       }
 
       if (req.method === "POST" && path === "/api/kill") {
-        mod.killMc();
-        res.end(JSON.stringify({ killed: true }));
+        const mcProcess = mod.getMcProcess();
+        if (!mcProcess || mcProcess.exitCode !== null) {
+          res.end(JSON.stringify({ killed: false, reason: "No managed Minecraft process is running." }));
+          return;
+        }
+        const killed = mod.killMc();
+        res.end(JSON.stringify(killed ? { killed, signal: process.platform === "win32" ? "taskkill" : "SIGTERM" }
+          : { killed, reason: "Failed to signal the managed Minecraft process." }));
         return;
       }
 

--- a/packages/minecraft-mod-mcp/src/api/modClient.test.ts
+++ b/packages/minecraft-mod-mcp/src/api/modClient.test.ts
@@ -1,0 +1,45 @@
+import { createServer, type Server } from "node:http";
+import { afterEach, describe, expect, it } from "vitest";
+import { ModClient } from "./modClient.js";
+
+let server: Server | undefined;
+
+afterEach(async () => {
+  if (server?.listening) await new Promise<void>((resolve) => server!.close(() => resolve()));
+  server = undefined;
+});
+
+describe("ModClient", () => {
+  it("reports external client metadata and clears a stale connection", async () => {
+    server = createServer((_req, res) => {
+      res.setHeader("Content-Type", "application/json");
+      res.end(JSON.stringify({
+        ok: true,
+        type: "minecraft-mod",
+        version: "26.2",
+        loader: "forge",
+        pid: 4242,
+        port: (server!.address() as { port: number }).port,
+        uptime: 12.5,
+      }));
+    });
+    await new Promise<void>((resolve) => server!.listen(0, "127.0.0.1", resolve));
+    const port = (server.address() as { port: number }).port;
+    const client = new ModClient();
+
+    await expect(client.checkAlive(port, port)).resolves.toBe(true);
+    expect(client.getStatus()).toMatchObject({
+      connected: true,
+      processAlive: false,
+      processManaged: false,
+      pid: 4242,
+      uptime: 12.5,
+      version: "26.2",
+      loader: "forge",
+    });
+
+    await new Promise<void>((resolve) => server!.close(() => resolve()));
+    await expect(client.checkAlive(port, port)).resolves.toBe(false);
+    expect(client.getStatus()).toMatchObject({ connected: false, port: null, pid: null });
+  });
+});

--- a/packages/minecraft-mod-mcp/src/api/modClient.ts
+++ b/packages/minecraft-mod-mcp/src/api/modClient.ts
@@ -6,47 +6,74 @@ import { MCP, MOD } from "../mc/defaults.js";
 export class ModClient {
   private modPort: number | null = null;
   private baseUrl = "";
+  private modStatus: ModStatus | null = null;
   private mcProcess: ReturnType<typeof import("node:child_process").spawn> | null = null;
 
   get connected(): boolean {
     return this.modPort !== null;
   }
 
-  getStatus(): { connected: boolean; port: number | null; processAlive: boolean } {
+  getStatus() {
+    const processAlive = this.mcProcess !== null && this.mcProcess.exitCode === null;
     return {
       connected: this.connected,
       port: this.modPort,
-      processAlive: this.mcProcess !== null && this.mcProcess.exitCode === null,
+      processAlive,
+      processManaged: this.mcProcess !== null,
+      pid: this.modStatus?.pid ?? null,
+      uptime: this.modStatus?.uptime ?? null,
+      version: this.modStatus?.version ?? null,
+      loader: this.modStatus?.loader ?? null,
+      forgeVersion: this.modStatus?.forgeVersion ?? null,
     };
   }
 
-  async discover(startPort = PORT_START, endPort = PORT_END): Promise<ModStatus | null> {
+  private connect(status: ModStatus): void {
+    this.modPort = status.port;
+    this.baseUrl = `http://${MCP.bindAddress}:${status.port}`;
+    this.modStatus = status;
+  }
+
+  async discover(startPort: number = PORT_START, endPort: number = PORT_END): Promise<ModStatus | null> {
+    const previousStatus = this.modStatus;
     const status = await findMod(startPort, endPort);
-    if (status) {
-      this.modPort = status.port;
-      this.baseUrl = `http://${MCP.bindAddress}:${status.port}`;
-    }
+    if (status) this.connect(status);
+    else if (previousStatus === this.modStatus) this.disconnect();
     return status;
   }
 
   async waitForConnection(timeoutMs: number = MCP.waitTimeoutMs): Promise<ModStatus | null> {
+    const previousStatus = this.modStatus;
     const status = await waitForMod(PORT_START, PORT_END, timeoutMs);
-    if (status) {
-      this.modPort = status.port;
-      this.baseUrl = `http://${MCP.bindAddress}:${status.port}`;
-    }
+    if (status) this.connect(status);
+    else if (previousStatus === this.modStatus) this.disconnect();
     return status;
   }
 
-  async checkAlive(): Promise<boolean> {
-    if (!this.modPort) return false;
-    const s = await probePort(this.modPort);
-    return s !== null;
+  async checkAlive(startPort: number = PORT_START, endPort: number = PORT_END): Promise<boolean> {
+    if (!this.modPort) {
+      await this.discover(startPort, endPort);
+      return this.connected;
+    }
+    const port = this.modPort;
+    const previousStatus = this.modStatus;
+    const status = await probePort(port);
+    if (previousStatus === this.modStatus && port === this.modPort) {
+      if (status) {
+        this.connect(status);
+        return true;
+      }
+      this.disconnect();
+      await this.discover(startPort, endPort);
+      return this.connected;
+    }
+    return this.connected;
   }
 
   private disconnect(): void {
     this.modPort = null;
     this.baseUrl = "";
+    this.modStatus = null;
   }
 
   async sendCommand(method: string, params?: Record<string, unknown>): Promise<unknown> {
@@ -54,21 +81,25 @@ export class ModClient {
       await this.discover();
       if (!this.baseUrl) throw new Error("Mod not connected");
     }
+    const baseUrl = this.baseUrl;
+    const pid = this.modStatus?.pid;
     const body: Record<string, unknown> = { cmd: method, ...(params || {}) };
+    let httpError = false;
     try {
-      const resp = await fetch(`${this.baseUrl}${MOD.cmdEndpoint}`, {
+      const resp = await fetch(`${baseUrl}${MOD.cmdEndpoint}`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(body),
       });
       if (!resp.ok) {
+        if (resp.status >= 500 && baseUrl === this.baseUrl && pid === this.modStatus?.pid) this.disconnect();
+        httpError = true;
         const text = await resp.text();
-        if (resp.status === 502 || resp.status === 503) this.disconnect();
         throw new Error(`Mod returned ${resp.status}: ${text}`);
       }
-      return resp.json();
+      return await resp.json();
     } catch (err: any) {
-      if (err.cause?.code === "ECONNREFUSED") this.disconnect();
+      if (!httpError && baseUrl === this.baseUrl && pid === this.modStatus?.pid) this.disconnect();
       throw err;
     }
   }
@@ -78,12 +109,19 @@ export class ModClient {
       await this.discover();
       if (!this.baseUrl) throw new Error("Mod not connected");
     }
+    const baseUrl = this.baseUrl;
+    const pid = this.modStatus?.pid;
+    let httpError = false;
     try {
-      const resp = await fetch(`${this.baseUrl}${MOD.screenshotEndpoint}`);
-      if (!resp.ok) throw new Error(`Screenshot failed: ${resp.status}`);
-      return resp.json();
+      const resp = await fetch(`${baseUrl}${MOD.screenshotEndpoint}`);
+      if (!resp.ok) {
+        if (resp.status >= 500 && baseUrl === this.baseUrl && pid === this.modStatus?.pid) this.disconnect();
+        httpError = true;
+        throw new Error(`Screenshot failed: ${resp.status}`);
+      }
+      return await resp.json();
     } catch (err: any) {
-      if (err.cause?.code === "ECONNREFUSED") this.disconnect();
+      if (!httpError && baseUrl === this.baseUrl && pid === this.modStatus?.pid) this.disconnect();
       throw err;
     }
   }
@@ -96,14 +134,17 @@ export class ModClient {
     return this.mcProcess;
   }
 
-  killMc() {
+  killMc(): boolean {
     if (this.mcProcess && this.mcProcess.exitCode === null) {
       if (process.platform === "win32") {
-        try { execSync(`taskkill /PID ${this.mcProcess.pid} /T /F`, { stdio: "ignore" }); } catch {}
+        try { execSync(`taskkill /PID ${this.mcProcess.pid} /T /F`, { stdio: "ignore" }); }
+        catch { return false; }
       } else {
-        this.mcProcess.kill("SIGTERM");
+        if (!this.mcProcess.kill("SIGTERM")) return false;
       }
       this.mcProcess = null;
+      return true;
     }
+    return false;
   }
 }

--- a/packages/minecraft-mod-mcp/src/consts.ts
+++ b/packages/minecraft-mod-mcp/src/consts.ts
@@ -18,7 +18,13 @@ export interface ModStatus {
 export function isModStatus(obj: unknown): obj is ModStatus {
   if (typeof obj !== "object" || obj === null) return false;
   const o = obj as Record<string, unknown>;
-  return o.ok === true && o.type === MOD.statusType && typeof o.port === "number";
+  return o.ok === true
+    && o.type === MOD.statusType
+    && typeof o.version === "string"
+    && typeof o.loader === "string"
+    && typeof o.pid === "number"
+    && typeof o.port === "number"
+    && typeof o.uptime === "number";
 }
 
 export interface ServerPorts {

--- a/packages/minecraft-mod-mcp/src/discovery/scanner.ts
+++ b/packages/minecraft-mod-mcp/src/discovery/scanner.ts
@@ -8,17 +8,17 @@ export async function probePort(port: number): Promise<ModStatus | null> {
     const resp = await fetch(`http://${MCP.bindAddress}:${port}${MOD.statusEndpoint}`, {
       signal: controller.signal,
     });
-    clearTimeout(timer);
     if (!resp.ok) return null;
     const body = await resp.json();
     return isModStatus(body) ? body : null;
   } catch {
-    clearTimeout(timer);
     return null;
+  } finally {
+    clearTimeout(timer);
   }
 }
 
-export async function findMod(startPort = PORT_START, endPort = PORT_END): Promise<ModStatus | null> {
+export async function findMod(startPort: number = PORT_START, endPort: number = PORT_END): Promise<ModStatus | null> {
   for (let port = startPort; port >= endPort; port--) {
     const status = await probePort(port);
     if (status) return status;
@@ -41,7 +41,7 @@ export async function waitForMod(
   return null;
 }
 
-export async function findFreePort(startPort = PORT_START, endPort = PORT_END): Promise<number> {
+export async function findFreePort(startPort: number = PORT_START, endPort: number = PORT_END): Promise<number> {
   const { createServer } = await import("node:net");
   for (let port = startPort; port >= endPort; port--) {
     const ok = await new Promise<boolean>((resolve) => {

--- a/packages/minecraft-mod-mcp/src/mcp/handlers.ts
+++ b/packages/minecraft-mod-mcp/src/mcp/handlers.ts
@@ -140,8 +140,13 @@ async function handleTool(name: string, params: Record<string, unknown>, mod: Mo
       return await launchMinecraft(params, mod);
     }
     case "kill_minecraft": {
-      mod.killMc();
-      return { killed: true };
+      const mcProcess = mod.getMcProcess();
+      if (!mcProcess || mcProcess.exitCode !== null) {
+        return { killed: false, reason: "No managed Minecraft process is running." };
+      }
+      const killed = mod.killMc();
+      return killed ? { killed, signal: process.platform === "win32" ? "taskkill" : "SIGTERM" }
+        : { killed, reason: "Failed to signal the managed Minecraft process." };
     }
     case "get_minecraft_status": {
       await mod.checkAlive();

--- a/packages/minecraft-mod-mcp/src/mcp/tools.ts
+++ b/packages/minecraft-mod-mcp/src/mcp/tools.ts
@@ -272,12 +272,12 @@ export const TOOLS: ToolDef[] = [
   },
   {
     name: "kill_minecraft",
-    description: "Kill the running Minecraft process.",
+    description: "Kill the Minecraft process started by this bridge.",
     inputSchema: z.object({}),
   },
   {
     name: "get_minecraft_status",
-    description: "Get Minecraft process and mod connection status.",
+    description: "Probe the mod and report its PID, version, loader, uptime, port, and managed-process status.",
     inputSchema: z.object({}),
   },
   {

--- a/packages/minecraft-mod-mcp/src/server.ts
+++ b/packages/minecraft-mod-mcp/src/server.ts
@@ -1,6 +1,5 @@
 import { ModClient } from "./api/modClient.js";
 import { createMcpServer, connectStdio } from "./mcp/transport.js";
-import { findMod } from "./discovery/scanner.js";
 import { PORT_START, PORT_END } from "./consts.js";
 import { MCP, SERVER } from "./mc/defaults.js";
 
@@ -23,9 +22,8 @@ export async function startServer(opts: ServerOptions = {}): Promise<void> {
 function discoverInBackground(mod: ModClient, timeout?: number): void {
   (async () => {
     log(`Scanning for Minecraft mod (${PORT_START}-${PORT_END})...`);
-    const status = await findMod(PORT_START, PORT_END);
+    const status = await mod.discover(PORT_START, PORT_END);
     if (status) {
-      await mod.discover();
       log(`Found mod: ${status.version}-${status.loader} (pid ${status.pid}) on port ${status.port}`);
     } else {
       log("No mod found. Background scanning every 5s...");


### PR DESCRIPTION
## Summary

Improve MCP reliability for externally launched Minecraft clients on Wayland, including Prism Launcher instances, and correct modern keyboard input delivery.

## Changes

- Report external mod PID, uptime, version, loader, and port.
- Clear stale connections and rediscover restarted clients.
- Prevent stale concurrent probes from overwriting fresh connection state.
- Route LWJGL3 key events through Minecraft's keyboard handler.
- Release held keys asynchronously without blocking the render thread.
- Support canonical prefixed key names and modifier aliases.
- Bind the unauthenticated mod control API to loopback only.
- Report managed-process kill failures accurately.
- Add Wayland and Hyprland troubleshooting documentation.
- Add an external-client lifecycle regression test.
- Bump the bridge package version to 0.3.1.

## Tested

- [ ] Build passes (`just full`)
- [ ] Smoke test passes on at least one version (`just smoke <version>`)
- [x] `npm test`
- [x] `npm run lint`
- [x] `npm run build`
- [x] Common Gradle build
- [x] Minecraft 26.2 Forge 65.1.3 build
- [x] PR title follows `<gitmoji> <Sentence.>`

`just full` was unavailable locally. Equivalent targeted builds passed. No live Minecraft session was started.