### PR TITLE
🐛 Log each E2E step outcome so failures are visible in the job log.

### DIFF
--- a/scripts/ci_helper.py
+++ b/scripts/ci_helper.py
@@ -914,8 +914,10 @@ def run_e2e_test(mc_ver, loader, jdk_ver, mod_jar, world_name, timeout=600):
         try:
             resp = api_call(mod_url, cmd, params)
             results[step_name] = {"passed": validator(resp), "detail": str(resp)[:100]}
+            _log(f"  E2E [{step_name}]: {'PASS' if results[step_name]['passed'] else 'FAIL'}")
         except Exception as e:
             results[step_name] = {"passed": False, "detail": str(e)}
+            _log(f"  E2E [{step_name}]: ERROR - {e}")
 
     steps_to_screenshot = ["01_ingame", "02_inventory", "03_sign_placed"]
     for label in steps_to_screenshot:
@@ -933,6 +935,7 @@ def run_e2e_test(mc_ver, loader, jdk_ver, mod_jar, world_name, timeout=600):
                 results[f"compare_{label}"] = {"passed": ok2, "detail": detail2}
         except Exception as e:
             results[f"screenshot_{label}"] = {"passed": False, "detail": str(e)}
+            _log(f"  E2E [screenshot {label}]: ERROR - {e}")
 
     kill_minecraft()
     if mc_proc and mc_proc.poll() is None:


### PR DESCRIPTION
The E2E loop records failures into its results dict but prints nothing, so a run where the game dies right after the mod handshake shows only 'Mod ready' followed by exit 1 with zero diagnostics. Emit a log line per step (and per screenshot stage) so the next run pinpoints the failing call. Diagnostic-only; push-event lanes verify.